### PR TITLE
fix(ci): redeploy Pages after automated Credly badge sync

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,10 +28,6 @@ jobs:
       steps:
          - name: Checkout code
            uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-           with:
-              # On workflow_run the event SHA predates the sync bot's commit, so
-              # check out the branch HEAD to pick up the freshly-synced data.
-              ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
 
          - name: Setup pnpm
            uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,12 @@ on:
       branches: [main]
    pull_request:
       branches: [main]
+   # Rebuild after the Credly sync bot pushes new badge data. A push by the
+   # default GITHUB_TOKEN does not retrigger `on: push`, so deploy via
+   # workflow_run instead (not subject to that restriction).
+   workflow_run:
+      workflows: ["Sync Credly Badges"]
+      types: [completed]
 
 # Allow only one concurrent deployment
 concurrency:
@@ -22,6 +28,10 @@ jobs:
       steps:
          - name: Checkout code
            uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+           with:
+              # On workflow_run the event SHA predates the sync bot's commit, so
+              # check out the branch HEAD to pick up the freshly-synced data.
+              ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
 
          - name: Setup pnpm
            uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4
@@ -63,7 +73,9 @@ jobs:
               path: "build"
 
    deploy:
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: >
+         (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+         (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
       permissions:
          pages: write
          id-token: write


### PR DESCRIPTION
## Problem

The weekly `sync-credly.yml` workflow correctly fetches badges and commits `data/achievements.json` (latest: 27cc548, Jun 15). But the live site never updates.

Root cause: the sync job pushes using the default `GITHUB_TOKEN`. GitHub deliberately does **not** retrigger `on: push` workflows for pushes made with that token (loop prevention). So `ci-cd.yml` ignores every sync commit -- no rebuild, no `deploy-pages`. Since the JSON is baked into the Vite bundle at build time, the deployed badges stay frozen at whatever the last human/PR push produced.

Confirmed in run history: no CI/CD run exists for 27cc548 or the prior sync commit; last real deploy was the Jun 13 esbuild bump.

## Fix

- Add a `workflow_run` trigger on "Sync Credly Badges" (`completed`). `workflow_run` events are not subject to the GITHUB_TOKEN restriction.
- Broaden the `deploy` job `if` to accept a successful `workflow_run`.
- Pin `actions/checkout` to the branch HEAD on `workflow_run` -- the event SHA predates the bot commit, so this ensures the build sees the freshly-synced data.

No PAT or secret required.

## Testing

- YAML validated (parses; triggers = push, pull_request, workflow_run; deploy gate intact).
- Merging this PR is itself a push to main, which deploys and carries the already-synced Jun 15 badges live.
- Next weekly sync will auto-deploy via the new `workflow_run` path.