### PR TITLE
feat: UI elevation -- accessibility, scroll/load performance, motion polish, token consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project are documented here. Follows [Semantic Versioning](https://semver.org/).
 
+## [3.15.0] - 2026-06-28
+
+### Added
+
+- **Accessibility**: skip-to-content link, `main` landmark, nav `aria-label`/`aria-current`/`aria-expanded`/`aria-controls`, contact-form inline error with `aria-invalid` + `role="alert"`, screen-reader announcement on send success
+- **MobileMenu** is now a real dialog -- focus trap, Escape to close, body scroll-lock, focus return to the trigger (reuses `useFocusTrap`)
+- **GitHub calendar**: explicit timeout fallback with a link to the live profile when the contribution data is slow
+- `MAX_WIDTH_WIDE` / `MAX_WIDTH_FORM` layout tokens; `--ch-red` channel; `credlyThumb` render-time image-resize helper
+
+### Changed
+
+- **Performance (scroll)**: replaced the full-width `.section-darker` backdrop-blur bands with gradient overlays (the dominant fast-scroll repaint), animated AuroraBlobs via `transform` instead of `left/top`, paused the 3D frameloop during active scroll, gated the 3D scene to desktop, stopped transitioning the nav blur radius, reduced glass blur 12->10px
+- **Performance (load)**: Credly badges now request `/size/220x220` thumbnails (~43KB->25KB each across 20 badges, sharper on retina)
+- **Scroll feel**: Lenis tuned to lerp-based smoothing for responsive fast scrolling; all in-page scroll actions routed through Lenis; `overscroll-behavior` added
+- **Design system**: routed raw hex/rgba/easing literals through `theme.ts` tokens and `--ch-*` channels across the component tree; wired `MAX_WIDTH*`/type tokens into sections; bumped `TEXT_MUTED` for WCAG AA contrast; removed the cursor-following conic-gradient card border for a calmer, cheaper hover
+- **Motion**: `once: true` on entrance reveals (no replay on scroll-up), press feedback on key controls, `tabular-nums` on counters
+
+### Fixed
+
+- **AnimatedCounter**: cancel rAF on unmount, render decimal values correctly (e.g. CGPA), drop redundant one-shot ref
+- **ParticleField**: regenerate positions when `count` changes to avoid buffer-length desync
+- **InteractiveConstellation**: cancel rAF before restart so a `visibilitychange` cannot stack render loops
+- **Contact form**: preserve sender name for the success screen, surface non-200 send responses instead of failing silently
+- `parseDate` guards unknown months/years; stable React keys for repeated list strings
+
+### Removed
+
+- Dead `BLUE` color token
+
 ## [3.14.0] - 2026-05-03
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "portfolio-react",
-   "version": "3.14.0",
+   "version": "3.15.0",
    "type": "module",
    "private": true,
    "homepage": "https://sagargupta.online/portfolio-react/",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import InteractiveConstellation from "@components/ui/InteractiveConstellation";
 import SystemStatus from "@components/ui/SystemStatus";
 import { hasWebGL } from "@components/layout/Header/heroConstants";
 import { BreakpointProvider } from "@hooks/BreakpointProvider";
+import useBreakpoint from "@hooks/useBreakpoint";
 
 // Global interactive 3D background, lazy-loaded so Three.js stays out of the
 // initial bundle. Falls back to the 2D constellation when WebGL is unavailable.
@@ -35,6 +36,7 @@ const GitHub = lazy(() => import("@pages/github/GitHub"));
 
 const App = () => {
    const [webGLSupported] = useState(() => hasWebGL());
+   const { isMobile } = useBreakpoint();
 
    useEffect(() => {
       globalThis.history.scrollRestoration = "manual";
@@ -45,8 +47,13 @@ const App = () => {
       <ReactLenis
          root
          options={{
-            duration: 1,
-            easing: (t: number) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
+            // lerp-based smoothing (not a fixed duration) so a fast flick
+            // resolves quickly instead of being forced through a full 1s curve --
+            // keeps scrolling smooth but responsive when the user scrolls hard.
+            lerp: 0.1,
+            wheelMultiplier: 1.1,
+            touchMultiplier: 1.5,
+            syncTouch: false,
          }}
       >
          <BreakpointProvider>
@@ -56,7 +63,7 @@ const App = () => {
             <KeyboardNav />
             <AuroraBlobs />
             <ShootingStars />
-            {webGLSupported ? (
+            {webGLSupported && !isMobile ? (
                <ErrorBoundary fallback={<InteractiveConstellation />}>
                   <Suspense fallback={null}>
                      <SceneBackground />
@@ -67,8 +74,11 @@ const App = () => {
             )}
             <ParallaxElements />
             <div className="relative min-h-screen">
+               <a href="#main-content" className="skip-link">
+                  Skip to content
+               </a>
                <Nav />
-               <main>
+               <main id="main-content" tabIndex={-1}>
                   <Hero />
                   <Suspense fallback={<SectionLoader />}>
                      <SectionTransition variant="gradient-sweep" />

--- a/src/components/3d/ParticleField.tsx
+++ b/src/components/3d/ParticleField.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unknown-property */
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useMemo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -20,7 +20,10 @@ interface ParticleFieldProps {
 
 const ParticleField = ({ count = 300 }: ParticleFieldProps) => {
    const ref = useRef<THREE.Points>(null);
-   const [positions] = useState(() => createParticlePositions(count));
+   // Regenerate when count changes (degraded mode / breakpoint cross). A one-shot
+   // useState would keep the old-length array while the bufferAttribute count
+   // changed, reading past/short the buffer and collapsing particles.
+   const positions = useMemo(() => createParticlePositions(count), [count]);
 
    useFrame((_, delta) => {
       if (ref.current) {
@@ -47,7 +50,7 @@ const ParticleField = ({ count = 300 }: ParticleFieldProps) => {
             <bufferAttribute
                attach="attributes-position"
                args={[positions, 3]}
-               count={count}
+               count={positions.length / 3}
             />
          </bufferGeometry>
          <pointsMaterial

--- a/src/components/3d/SceneBackground.tsx
+++ b/src/components/3d/SceneBackground.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 import { Canvas, useFrame } from "@react-three/fiber";
 import { PerformanceMonitor } from "@react-three/drei";
+import { useLenis } from "lenis/react";
 import * as THREE from "three";
 import FloatingGeometry from "./FloatingGeometry";
 import ParticleField from "./ParticleField";
@@ -65,7 +66,23 @@ const SceneBackground = () => {
    const { isMobile } = useBreakpoint();
    const reducedMotion = useReducedMotion();
    const [degraded, setDegraded] = useState(false);
+   const [scrolling, setScrolling] = useState(false);
    const pointer = useRef<Pointer>({ x: 0, y: 0 });
+   const scrollIdle = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+   // Pause the render loop while the user is actively scrolling, resume ~160ms
+   // after they stop. The 3D scene contributes nothing during a fast fling (it's
+   // behind blurred glass and moving past) but competes for GPU/main thread with
+   // the scroll -- freeing it is a direct fast-scroll smoothness win. Motion stays
+   // fully visible at rest, which is when the parallax actually reads.
+   useLenis(({ velocity }) => {
+      if (Math.abs(velocity) < 0.05) return;
+      if (!scrolling) setScrolling(true);
+      clearTimeout(scrollIdle.current);
+      scrollIdle.current = setTimeout(() => setScrolling(false), 160);
+   });
+
+   useEffect(() => () => clearTimeout(scrollIdle.current), []);
 
    useEffect(() => {
       const setFromXY = (clientX: number, clientY: number) => {
@@ -101,8 +118,10 @@ const SceneBackground = () => {
          }}
          camera={{ position: [0, 0, 8], fov: 50 }}
          dpr={dpr}
-         // Reduced motion -> render once and freeze (static 3D snapshot).
-         frameloop={reducedMotion ? "demand" : "always"}
+         // Reduced motion -> render once and freeze. While actively scrolling ->
+         // pause the loop ("demand") to free the GPU/main thread for the scroll;
+         // resume "always" at rest.
+         frameloop={reducedMotion || scrolling ? "demand" : "always"}
          gl={{
             antialias: !isMobile,
             alpha: true,

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { motion } from "motion/react";
 import { staggerContainer } from "@utils/animations";
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, CYAN } from "@/constants/theme";
 import FooterContent from "./FooterContent";
 
 const KONAMI: string[] = [
@@ -93,7 +93,7 @@ const Footer = () => {
                      border: "1px solid rgba(6,182,212,0.3)",
                      fontFamily: MONO_FONT,
                      fontSize: 12,
-                     color: "#06b6d4",
+                     color: CYAN,
                      textAlign: "center",
                   }}
                >

--- a/src/components/layout/Footer/FooterContent.tsx
+++ b/src/components/layout/Footer/FooterContent.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { motion } from "motion/react";
 import { getName, getSiteConfig } from "@data/dataLoader";
 import { staggerItem } from "@utils/animations";
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, CYAN, TEXT_MUTED } from "@/constants/theme";
 import useBreakpoint from "@hooks/useBreakpoint";
 import FooterSocial from "./FooterSocial";
 
@@ -21,7 +21,7 @@ const FooterContent = () => {
                fontFamily: MONO_FONT,
                fontSize: 24,
                fontWeight: 700,
-               color: "#06b6d4",
+               color: CYAN,
             }}
             variants={staggerItem}
          >
@@ -56,7 +56,7 @@ const FooterContent = () => {
                   key={tech}
                   style={{
                      fontSize: 10,
-                     color: "#6e6e90",
+                     color: TEXT_MUTED,
                      fontFamily: MONO_FONT,
                      padding: "2px 8px",
                      borderRadius: 4,
@@ -81,7 +81,7 @@ const FooterContent = () => {
          >
             <p
                style={{
-                  color: "#6e6e90",
+                  color: TEXT_MUTED,
                   fontSize: 14,
                   textAlign: "center",
                }}

--- a/src/components/layout/Footer/FooterSocial.tsx
+++ b/src/components/layout/Footer/FooterSocial.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { motion } from "motion/react";
 import { getSocialProfiles } from "@data/dataLoader";
 import { staggerItem } from "@utils/animations";
+import { TEXT_SECONDARY, CYAN } from "@/constants/theme";
 import ICON_MAP from "@utils/iconMap";
 
 const FooterSocial = () => {
@@ -32,18 +33,18 @@ const FooterSocial = () => {
                      display: "flex",
                      alignItems: "center",
                      justifyContent: "center",
-                     color: "#a5a5c0",
+                     color: TEXT_SECONDARY,
                      transition: "all 0.3s",
                   }}
                   onMouseEnter={(e: React.MouseEvent<HTMLAnchorElement>) => {
-                     e.currentTarget.style.color = "#06b6d4";
+                     e.currentTarget.style.color = CYAN;
                      e.currentTarget.style.borderColor =
                         "rgba(6, 182, 212, 0.3)";
                      e.currentTarget.style.background =
                         "rgba(6, 182, 212, 0.08)";
                   }}
                   onMouseLeave={(e: React.MouseEvent<HTMLAnchorElement>) => {
-                     e.currentTarget.style.color = "#a5a5c0";
+                     e.currentTarget.style.color = TEXT_SECONDARY;
                      e.currentTarget.style.borderColor =
                         "rgba(255, 255, 255, 0.06)";
                      e.currentTarget.style.background =

--- a/src/components/layout/Header/Hero.tsx
+++ b/src/components/layout/Header/Hero.tsx
@@ -1,13 +1,17 @@
 import { useCallback } from "react";
 import { motion } from "motion/react";
+import { useLenis } from "lenis/react";
 import { ChevronDown } from "lucide-react";
 import HeroContent from "./HeroContent";
 
 const Hero = () => {
+   const lenis = useLenis();
    const scrollToAbout = useCallback(() => {
-      const el = document.querySelector("#about");
-      if (el) el.scrollIntoView({ behavior: "smooth" });
-   }, []);
+      const el = document.getElementById("about");
+      if (!el) return;
+      if (lenis) lenis.scrollTo(el, { offset: -64 });
+      else el.scrollIntoView();
+   }, [lenis]);
 
    return (
       <section

--- a/src/components/layout/Header/HeroContent.tsx
+++ b/src/components/layout/Header/HeroContent.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { motion, AnimatePresence } from "motion/react";
+import { useLenis } from "lenis/react";
 import { getName, getRoles } from "@data/dataLoader";
 import { staggerContainer, staggerItem } from "@utils/animations";
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, GREEN } from "@/constants/theme";
 import HeroStats from "./HeroStats";
 import HeroSocial from "./HeroSocial";
 const RESUME_URL =
@@ -21,10 +22,13 @@ const HeroContent = () => {
       return () => clearInterval(interval);
    }, [roles]);
 
+   const lenis = useLenis();
    const scrollToProjects = useCallback(() => {
-      const el = document.querySelector("#projects");
-      if (el) el.scrollIntoView({ behavior: "smooth" });
-   }, []);
+      const el = document.getElementById("projects");
+      if (!el) return;
+      if (lenis) lenis.scrollTo(el, { offset: -64 });
+      else el.scrollIntoView();
+   }, [lenis]);
 
    return (
       <motion.div
@@ -42,7 +46,7 @@ const HeroContent = () => {
                   gap: 8,
                   fontFamily: MONO_FONT,
                   fontSize: 14,
-                  color: "#22c55e",
+                  color: GREEN,
                   background: "rgba(34, 197, 94, 0.06)",
                   backdropFilter: "blur(12px)",
                   WebkitBackdropFilter: "blur(12px)",

--- a/src/components/layout/Header/HeroSocial.tsx
+++ b/src/components/layout/Header/HeroSocial.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { motion } from "motion/react";
 import { getSocialProfiles } from "@data/dataLoader";
 import { staggerItem } from "@utils/animations";
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, TEXT_SECONDARY, CYAN } from "@/constants/theme";
 import ICON_MAP from "@utils/iconMap";
 
 const HeroSocial = () => {
@@ -24,7 +24,7 @@ const HeroSocial = () => {
                   WebkitBackdropFilter: "blur(12px)",
                   border: "1px solid rgba(255, 255, 255, 0.06)",
                   fontSize: 12,
-                  color: "#a5a5c0",
+                  color: TEXT_SECONDARY,
                }}
             >
                <span style={{ fontSize: 14 }}>&#128640;</span>
@@ -36,7 +36,7 @@ const HeroSocial = () => {
                         fontFamily: MONO_FONT,
                         fontWeight: 600,
                         fontSize: 11,
-                        color: "#06b6d4",
+                        color: CYAN,
                         padding: "2px 8px",
                         borderRadius: 6,
                         background: "rgba(6, 182, 212, 0.08)",
@@ -74,13 +74,13 @@ const HeroSocial = () => {
                         display: "flex",
                         alignItems: "center",
                         justifyContent: "center",
-                        color: "#a5a5c0",
+                        color: TEXT_SECONDARY,
                         transition: "all 0.3s",
                      }}
                      whileHover={{
                         scale: 1.15,
                         y: -3,
-                        color: "#06b6d4",
+                        color: CYAN,
                         borderColor: "rgba(6, 182, 212, 0.3)",
                         background: "rgba(6, 182, 212, 0.08)",
                      }}

--- a/src/components/layout/Navigation/DesktopNav.tsx
+++ b/src/components/layout/Navigation/DesktopNav.tsx
@@ -1,3 +1,5 @@
+import { memo } from "react";
+import { motion } from "motion/react";
 import { CYAN, TEXT_PRIMARY } from "@/constants/theme";
 
 interface NavSection {
@@ -29,9 +31,10 @@ const DesktopNav = ({
          {sections.map((section) => {
             const isActive = activeSection === section.id;
             return (
-               <button
+               <motion.button
                   key={section.id}
                   onClick={() => onNavigate(section.id)}
+                  whileTap={{ scale: 0.94 }}
                   style={{
                      padding: "4px 12px",
                      fontSize: 12,
@@ -39,7 +42,8 @@ const DesktopNav = ({
                      borderRadius: 10,
                      cursor: "pointer",
                      border: "none",
-                     transition: "all 0.2s ease",
+                     transition:
+                        "color 0.2s ease, background-color 0.2s ease",
                      color: isActive ? CYAN : "rgba(165, 165, 192, 0.9)",
                      backgroundColor: isActive
                         ? "rgba(6, 182, 212, 0.1)"
@@ -50,6 +54,7 @@ const DesktopNav = ({
                      gap: 4,
                      position: "relative",
                   }}
+                  aria-current={isActive ? "true" : undefined}
                   onMouseEnter={(e: React.MouseEvent<HTMLButtonElement>) => {
                      if (!isActive) {
                         e.currentTarget.style.color = TEXT_PRIMARY;
@@ -81,11 +86,11 @@ const DesktopNav = ({
                      />
                   )}
                   {section.label}
-               </button>
+               </motion.button>
             );
          })}
       </div>
    );
 };
 
-export default DesktopNav;
+export default memo(DesktopNav);

--- a/src/components/layout/Navigation/MobileMenu.tsx
+++ b/src/components/layout/Navigation/MobileMenu.tsx
@@ -1,5 +1,7 @@
+import { memo, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { CYAN, TEXT_SECONDARY } from "@/constants/theme";
+import { CYAN, TEXT_SECONDARY, GLASS_BORDER } from "@/constants/theme";
+import useFocusTrap from "@hooks/useFocusTrap";
 
 interface NavSection {
    id: string;
@@ -14,6 +16,22 @@ interface MobileMenuProps {
    onClose: () => void;
 }
 
+const rowStyle = (isActive: boolean): React.CSSProperties => ({
+   textAlign: "left",
+   padding: "12px 16px",
+   minHeight: 44,
+   display: "flex",
+   alignItems: "center",
+   borderRadius: 10,
+   fontSize: 14,
+   fontWeight: 500,
+   cursor: "pointer",
+   border: "none",
+   transition: "color 0.2s ease, background-color 0.2s ease",
+   color: isActive ? CYAN : TEXT_SECONDARY,
+   backgroundColor: isActive ? "rgb(var(--ch-cyan) / 0.08)" : "transparent",
+});
+
 const MobileMenu = ({
    open,
    sections,
@@ -21,6 +39,28 @@ const MobileMenu = ({
    onNavigate,
    onClose,
 }: MobileMenuProps) => {
+   const panelRef = useFocusTrap<HTMLDivElement>(open);
+
+   const onEsc = useCallback(
+      (e: KeyboardEvent) => {
+         if (e.key === "Escape") onClose();
+      },
+      [onClose],
+   );
+
+   // While open: lock body scroll and allow Escape to dismiss -- mirrors the
+   // project/experience modal behavior so the overlay can't be tabbed/scrolled
+   // behind on touch. useFocusTrap restores focus to the hamburger on close.
+   useEffect(() => {
+      if (!open) return;
+      document.body.style.overflow = "hidden";
+      document.addEventListener("keydown", onEsc);
+      return () => {
+         document.body.style.overflow = "";
+         document.removeEventListener("keydown", onEsc);
+      };
+   }, [open, onEsc]);
+
    return (
       <AnimatePresence>
          {open && (
@@ -45,16 +85,22 @@ const MobileMenu = ({
 
                {/* Slide-in panel */}
                <motion.div
+                  ref={panelRef}
+                  id="mobile-menu"
+                  role="dialog"
+                  aria-modal="true"
+                  aria-label="Navigation menu"
+                  tabIndex={-1}
                   style={{
                      position: "absolute",
                      top: 64,
                      right: 0,
                      bottom: 0,
-                     width: 288,
+                     width: "min(288px, 85vw)",
                      backgroundColor: "rgba(12, 12, 30, 0.7)",
                      backdropFilter: "blur(24px)",
                      WebkitBackdropFilter: "blur(24px)",
-                     borderLeft: "1px solid rgba(255, 255, 255, 0.06)",
+                     borderLeft: `1px solid ${GLASS_BORDER}`,
                      boxShadow: "-10px 0 40px rgba(0, 0, 0, 0.3)",
                   }}
                   initial={{ x: "100%" }}
@@ -76,22 +122,10 @@ const MobileMenu = ({
                   >
                      <button
                         onClick={() => onNavigate("hero")}
-                        style={{
-                           textAlign: "left",
-                           padding: "12px 16px",
-                           borderRadius: 10,
-                           fontSize: 14,
-                           fontWeight: 500,
-                           cursor: "pointer",
-                           border: "none",
-                           transition: "all 0.2s",
-                           color:
-                              activeSection === "hero" ? CYAN : TEXT_SECONDARY,
-                           backgroundColor:
-                              activeSection === "hero"
-                                 ? "rgba(6, 182, 212, 0.08)"
-                                 : "transparent",
-                        }}
+                        style={rowStyle(activeSection === "hero")}
+                        aria-current={
+                           activeSection === "hero" ? "true" : undefined
+                        }
                      >
                         Home
                      </button>
@@ -101,23 +135,11 @@ const MobileMenu = ({
                            <motion.button
                               key={section.id}
                               onClick={() => onNavigate(section.id)}
-                              style={{
-                                 textAlign: "left",
-                                 padding: "12px 16px",
-                                 borderRadius: 10,
-                                 fontSize: 14,
-                                 fontWeight: 500,
-                                 cursor: "pointer",
-                                 border: "none",
-                                 transition: "all 0.2s",
-                                 color: isActive ? CYAN : TEXT_SECONDARY,
-                                 backgroundColor: isActive
-                                    ? "rgba(6, 182, 212, 0.08)"
-                                    : "transparent",
-                              }}
+                              style={rowStyle(isActive)}
                               initial={{ opacity: 0, x: 20 }}
                               animate={{ opacity: 1, x: 0 }}
                               transition={{ delay: index * 0.03 }}
+                              aria-current={isActive ? "true" : undefined}
                               aria-label={`Navigate to ${section.label}`}
                            >
                               {section.label}
@@ -132,4 +154,4 @@ const MobileMenu = ({
    );
 };
 
-export default MobileMenu;
+export default memo(MobileMenu);

--- a/src/components/layout/Navigation/Nav.tsx
+++ b/src/components/layout/Navigation/Nav.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import useMediaQuery from "@hooks/useMediaQuery";
+import { useLenis } from "lenis/react";
+import useBreakpoint from "@hooks/useBreakpoint";
 import NavBar from "./NavBar";
 import MobileMenu from "./MobileMenu";
 
@@ -21,7 +22,7 @@ const NAV_SECTIONS: NavSection[] = [
 ];
 
 const Nav = () => {
-   const isMobile = useMediaQuery("(max-width: 1023px)");
+   const { isTablet: isMobile } = useBreakpoint();
    const [activeSection, setActiveSection] = useState("hero");
    const [sectionProgress, setSectionProgress] = useState(0);
    const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -67,13 +68,23 @@ const Nav = () => {
       return () => observer.disconnect();
    }, []);
 
-   const scrollToSection = useCallback((id: string) => {
-      const el = document.querySelector(`#${id}`);
-      if (el) {
-         el.scrollIntoView({ behavior: "smooth" });
-      }
-      setMobileMenuOpen(false);
-   }, []);
+   const lenis = useLenis();
+   const scrollToSection = useCallback(
+      (id: string) => {
+         const el = document.getElementById(id);
+         if (el) {
+            // Route through Lenis so smooth scrolling matches the rest of the
+            // page (CSS scroll-behavior is auto now, so native smooth is off).
+            if (lenis) lenis.scrollTo(el, { offset: -64 });
+            else el.scrollIntoView();
+         }
+         setMobileMenuOpen(false);
+      },
+      [lenis],
+   );
+
+   const toggleMenu = useCallback(() => setMobileMenuOpen((o) => !o), []);
+   const closeMenu = useCallback(() => setMobileMenuOpen(false), []);
 
    return (
       <>
@@ -85,7 +96,7 @@ const Nav = () => {
             sectionProgress={sectionProgress}
             mobileMenuOpen={mobileMenuOpen}
             onNavigate={scrollToSection}
-            onToggleMenu={() => setMobileMenuOpen(!mobileMenuOpen)}
+            onToggleMenu={toggleMenu}
          />
 
          {/* Mobile overlay menu */}
@@ -94,7 +105,7 @@ const Nav = () => {
             sections={NAV_SECTIONS}
             activeSection={activeSection}
             onNavigate={scrollToSection}
-            onClose={() => setMobileMenuOpen(false)}
+            onClose={closeMenu}
          />
       </>
    );

--- a/src/components/layout/Navigation/NavBar.tsx
+++ b/src/components/layout/Navigation/NavBar.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { motion } from "motion/react";
 import { Menu, X } from "lucide-react";
 import { MONO_FONT, CYAN, TEXT_SECONDARY } from "@/constants/theme";
@@ -41,18 +42,21 @@ const NavBar = ({
             backgroundColor: scrolled
                ? "rgba(10, 10, 26, 0.6)"
                : "rgba(10, 10, 26, 0.2)",
-            backdropFilter: scrolled ? "blur(24px)" : "blur(12px)",
-            WebkitBackdropFilter: scrolled ? "blur(24px)" : "blur(12px)",
+            backdropFilter: scrolled ? "blur(16px)" : "blur(12px)",
+            WebkitBackdropFilter: scrolled ? "blur(16px)" : "blur(12px)",
             boxShadow: scrolled
                ? "0 10px 40px rgba(0,0,0,0.3), inset 0 -1px 0 rgba(255,255,255,0.04)"
                : "none",
             borderBottom: "1px solid rgba(255, 255, 255, 0.04)",
-            transition:
-               "background-color 0.3s, backdrop-filter 0.3s, box-shadow 0.3s",
+            // Don't transition backdrop-filter -- animating the blur radius re-blurs
+            // the moving page through every intermediate kernel. Snap it; fade the
+            // bg/shadow instead.
+            transition: "background-color 0.3s, box-shadow 0.3s",
          }}
          initial={{ y: -80, opacity: 0 }}
          animate={{ y: 0, opacity: 1 }}
          transition={{ duration: 0.7, ease: "easeOut" }}
+         aria-label="Primary"
       >
          <div
             style={{
@@ -101,8 +105,8 @@ const NavBar = ({
                <button
                   onClick={onToggleMenu}
                   style={{
-                     width: 40,
-                     height: 40,
+                     width: 44,
+                     height: 44,
                      display: "flex",
                      alignItems: "center",
                      justifyContent: "center",
@@ -120,6 +124,8 @@ const NavBar = ({
                      e.currentTarget.style.color = TEXT_SECONDARY;
                   }}
                   aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
+                  aria-expanded={mobileMenuOpen}
+                  aria-controls="mobile-menu"
                >
                   {mobileMenuOpen ? <X size={22} /> : <Menu size={22} />}
                </button>
@@ -129,4 +135,4 @@ const NavBar = ({
    );
 };
 
-export default NavBar;
+export default memo(NavBar);

--- a/src/components/layout/PageSection.tsx
+++ b/src/components/layout/PageSection.tsx
@@ -31,7 +31,7 @@ const PageSection = ({
          }}
          initial="hidden"
          whileInView="visible"
-         viewport={{ margin: "0px 0px -100px 0px" }}
+         viewport={{ once: true, margin: "0px 0px -100px 0px" }}
          variants={sectionRevealEnhanced}
       >
          {maxWidth ? (

--- a/src/components/ui/ActivityFeed.tsx
+++ b/src/components/ui/ActivityFeed.tsx
@@ -7,6 +7,7 @@ import {
    CYAN,
    GLASS_PANEL_STYLE,
    CHROME_BAR_STYLE,
+   EASING,
 } from "@/constants/theme";
 import {
    PANEL_INITIAL,
@@ -70,7 +71,7 @@ const ActivityFeed = ({
                   transition={{
                      delay: 0.3 + i * 0.08,
                      duration: 0.4,
-                     ease: [0.16, 1, 0.3, 1],
+                     ease: EASING.cinematic,
                   }}
                   style={{
                      display: "block",

--- a/src/components/ui/AnimatedCounter.tsx
+++ b/src/components/ui/AnimatedCounter.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useInView } from "react-intersection-observer";
 
 interface Props {
@@ -8,56 +8,55 @@ interface Props {
 
 const AnimatedCounter = ({ value, duration = 2 }: Props) => {
    const [count, setCount] = useState<number>(0);
-   const hasAnimated = useRef<boolean>(false);
 
    const { ref, inView } = useInView({
       threshold: 0.5,
       triggerOnce: true,
    });
 
-   const { numericValue, suffix } = useMemo(() => {
+   // Parse a leading number (incl. one decimal point, e.g. "9.5") + trailing
+   // suffix (e.g. "+", "k"). decimals drives toFixed so values like a CGPA of
+   // 9.5 animate and land correctly instead of being truncated to an integer.
+   const { numericValue, decimals, suffix } = useMemo(() => {
       const str = String(value);
-      let i = 0;
-      while (i < str.length && str[i] >= "0" && str[i] <= "9") i++;
-      if (i > 0) {
+      const match = /^(\d+(?:\.\d+)?)(.*)$/s.exec(str);
+      if (match) {
+         const num = match[1];
+         const dot = num.indexOf(".");
          return {
-            numericValue: Number.parseInt(str.slice(0, i), 10),
-            suffix: str.slice(i),
+            numericValue: Number.parseFloat(num),
+            decimals: dot === -1 ? 0 : num.length - dot - 1,
+            suffix: match[2],
          };
       }
-      return { numericValue: 0, suffix: str };
+      return { numericValue: 0, decimals: 0, suffix: str };
    }, [value]);
 
    useEffect(() => {
-      if (!inView || hasAnimated.current) return;
-      hasAnimated.current = true;
+      if (!inView) return;
 
+      let rafId = 0;
       const startTime = performance.now();
       const durationMs = duration * 1000;
 
       const animate = (currentTime: number) => {
          const elapsed = currentTime - startTime;
          const progress = Math.min(elapsed / durationMs, 1);
-
          const eased = 1 - Math.pow(1 - progress, 3);
-         const current = Math.round(eased * numericValue);
-
-         setCount(current);
-
-         if (progress < 1) {
-            requestAnimationFrame(animate);
-         }
+         setCount(eased * numericValue);
+         if (progress < 1) rafId = requestAnimationFrame(animate);
       };
 
-      requestAnimationFrame(animate);
+      rafId = requestAnimationFrame(animate);
+      return () => cancelAnimationFrame(rafId);
    }, [inView, numericValue, duration]);
 
    return (
       <span
          ref={ref}
-         className="font-mono text-3xl font-bold text-accent-cyan glow-cyan-text"
+         className="font-mono text-3xl font-bold text-accent-cyan glow-cyan-text tabular-nums"
       >
-         {count}
+         {count.toFixed(decimals)}
          {suffix && <span className="text-accent-cyan/70">{suffix}</span>}
       </span>
    );

--- a/src/components/ui/AuroraBlobs.tsx
+++ b/src/components/ui/AuroraBlobs.tsx
@@ -1,15 +1,22 @@
 import { motion } from "motion/react";
 import useReducedMotion from "@hooks/useReducedMotion";
+import useBreakpoint from "@hooks/useBreakpoint";
 import { CYAN, PURPLE, PINK, AMBER } from "@/constants/theme";
 
+// Each blob is anchored at a fixed viewport position (left/top, set once) and
+// drifts via translate (x/y in px) -- a compositor-only animation. Animating
+// left/top would force a layout + paint every frame on a blur(80px) layer, which
+// is exactly what makes scrolling janky; translate stays on the GPU.
 const BLOBS = [
    {
       color: CYAN,
       rx: 300,
       ry: 220,
       opacity: 0.08,
-      x: [15, 55, 80, 30, 15],
-      y: [20, 60, 25, 75, 20],
+      left: "15%",
+      top: "18%",
+      x: [0, 90, -40, 60, 0],
+      y: [0, 70, 110, -30, 0],
       duration: 22,
    },
    {
@@ -17,8 +24,10 @@ const BLOBS = [
       rx: 260,
       ry: 300,
       opacity: 0.07,
-      x: [75, 30, 60, 85, 75],
-      y: [70, 30, 80, 40, 70],
+      left: "78%",
+      top: "62%",
+      x: [0, -120, 40, -80, 0],
+      y: [0, -90, 60, -40, 0],
       duration: 18,
    },
    {
@@ -26,8 +35,10 @@ const BLOBS = [
       rx: 280,
       ry: 240,
       opacity: 0.06,
-      x: [50, 80, 20, 65, 50],
-      y: [15, 55, 70, 35, 15],
+      left: "48%",
+      top: "20%",
+      x: [0, 110, -90, 70, 0],
+      y: [0, 80, 120, 40, 0],
       duration: 25,
    },
    {
@@ -35,14 +46,21 @@ const BLOBS = [
       rx: 240,
       ry: 280,
       opacity: 0.09,
-      x: [25, 70, 45, 10, 25],
-      y: [80, 20, 50, 40, 80],
+      left: "25%",
+      top: "78%",
+      x: [0, 100, 60, -70, 0],
+      y: [0, -110, -40, -80, 0],
       duration: 20,
    },
 ] as const;
 
 const AuroraBlobs = () => {
    const reducedMotion = useReducedMotion();
+   const { isMobile } = useBreakpoint();
+   // Halve the blurred (blur(80px)) layers on phones -- each is a continuously
+   // repainting fixed layer, the heaviest sustained GPU cost on mobile. Motion
+   // stays fully visible, just fewer simultaneous blobs.
+   const blobs = isMobile ? BLOBS.slice(0, 2) : BLOBS;
 
    return (
       <div
@@ -55,16 +73,11 @@ const AuroraBlobs = () => {
             overflow: "hidden",
          }}
       >
-         {BLOBS.map((blob) => (
+         {blobs.map((blob) => (
             <motion.div
                key={blob.color}
                animate={
-                  reducedMotion
-                     ? { left: `${blob.x[0]}%`, top: `${blob.y[0]}%` }
-                     : {
-                          left: blob.x.map((v) => `${v}%`),
-                          top: blob.y.map((v) => `${v}%`),
-                       }
+                  reducedMotion ? undefined : { x: [...blob.x], y: [...blob.y] }
                }
                transition={
                   reducedMotion
@@ -77,13 +90,15 @@ const AuroraBlobs = () => {
                }
                style={{
                   position: "absolute",
+                  left: blob.left,
+                  top: blob.top,
                   width: blob.rx,
                   height: blob.ry,
                   borderRadius: "50%",
                   background: blob.color,
                   opacity: blob.opacity,
                   filter: "blur(80px)",
-                  transform: "translate(-50%, -50%)",
+                  willChange: "transform",
                }}
             />
          ))}

--- a/src/components/ui/AvatarMonogram.tsx
+++ b/src/components/ui/AvatarMonogram.tsx
@@ -1,5 +1,5 @@
 import { motion } from "motion/react";
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, CYAN, PURPLE, GREEN } from "@/constants/theme";
 
 const AvatarMonogram = () => {
    return (
@@ -23,7 +23,7 @@ const AvatarMonogram = () => {
                fontSize: 48,
                fontWeight: 800,
                fontFamily: MONO_FONT,
-               background: "linear-gradient(135deg, #06b6d4, #a855f7)",
+               background: `linear-gradient(135deg, ${CYAN}, ${PURPLE})`,
                WebkitBackgroundClip: "text",
                WebkitTextFillColor: "transparent",
                lineHeight: 1,
@@ -38,7 +38,7 @@ const AvatarMonogram = () => {
             style={{
                fontFamily: MONO_FONT,
                fontSize: 11,
-               color: "#22c55e",
+               color: GREEN,
                letterSpacing: "0.1em",
             }}
             initial={{ opacity: 0 }}
@@ -51,7 +51,7 @@ const AvatarMonogram = () => {
             }}
          >
             {"> dev"}
-            <span style={{ color: "#06b6d4" }}>_</span>
+            <span style={{ color: CYAN }}>_</span>
          </motion.span>
       </div>
    );

--- a/src/components/ui/BackToTop.tsx
+++ b/src/components/ui/BackToTop.tsx
@@ -1,14 +1,16 @@
 import { useState, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "motion/react";
+import { useLenis } from "lenis/react";
 import { ChevronUp } from "lucide-react";
 import useBreakpoint from "@hooks/useBreakpoint";
-import { CYAN } from "@/constants/theme";
+import { CYAN, GLASS_BORDER } from "@/constants/theme";
 
 const SCROLL_THRESHOLD_PX = 500;
 
 const BackToTop = () => {
    const { isMobile } = useBreakpoint();
    const [visible, setVisible] = useState(false);
+   const lenis = useLenis();
 
    const handleScroll = useCallback(() => {
       setVisible(window.scrollY > SCROLL_THRESHOLD_PX);
@@ -20,12 +22,8 @@ const BackToTop = () => {
    }, [handleScroll]);
 
    const scrollToTop = () => {
-      const hero = document.getElementById("hero");
-      if (hero) {
-         hero.scrollIntoView({ behavior: "smooth" });
-      } else {
-         window.scrollTo({ top: 0, behavior: "smooth" });
-      }
+      if (lenis) lenis.scrollTo(0);
+      else window.scrollTo({ top: 0, behavior: "smooth" });
    };
 
    return (
@@ -38,21 +36,22 @@ const BackToTop = () => {
                exit={{ opacity: 0, scale: 0.8, y: 20 }}
                whileHover={{
                   y: -2,
-                  borderColor: "rgba(6,182,212,0.3)",
+                  borderColor: "rgb(var(--ch-cyan) / 0.3)",
                   boxShadow:
                      "0 0 25px rgba(6,182,212,0.15), 0 4px 20px rgba(0,0,0,0.3)",
                }}
+               whileTap={{ scale: 0.9 }}
                transition={{ duration: 0.25 }}
                style={{
                   position: "fixed",
                   bottom: isMobile ? 20 : 32,
                   right: isMobile ? 20 : 32,
                   zIndex: 50,
-                  width: isMobile ? 40 : 44,
-                  height: isMobile ? 40 : 44,
+                  width: 44,
+                  height: 44,
                   borderRadius: 12,
-                  border: "1px solid rgba(255,255,255,0.08)",
-                  background: "rgba(15,15,35,0.5)",
+                  border: `1px solid ${GLASS_BORDER}`,
+                  background: "rgb(var(--ch-glass) / 0.5)",
                   backdropFilter: "blur(20px)",
                   WebkitBackdropFilter: "blur(20px)",
                   color: CYAN,

--- a/src/components/ui/BrowserMockup.tsx
+++ b/src/components/ui/BrowserMockup.tsx
@@ -1,7 +1,12 @@
 import type { ReactNode } from "react";
 import { motion, useInView } from "motion/react";
 import { useRef } from "react";
-import { MONO_FONT, TEXT_MUTED, CHROME_BAR_STYLE } from "@/constants/theme";
+import {
+   MONO_FONT,
+   TEXT_MUTED,
+   CHROME_BAR_STYLE,
+   EASING,
+} from "@/constants/theme";
 
 interface BrowserMockupProps {
    children: ReactNode;
@@ -44,7 +49,7 @@ const BrowserMockup = ({
             }
             transition={{
                duration: 1,
-               ease: [0.16, 1, 0.3, 1],
+               ease: EASING.cinematic,
             }}
             style={{
                transformOrigin: "50% 2%",
@@ -77,7 +82,7 @@ const BrowserMockup = ({
                transition={{
                   duration: 1,
                   delay: 0.4,
-                  ease: [0.16, 1, 0.3, 1],
+                  ease: EASING.cinematic,
                }}
                style={{
                   position: "absolute",
@@ -196,7 +201,7 @@ const BrowserMockup = ({
                transition={{
                   delay: 0.5,
                   duration: 1,
-                  ease: [0.16, 1, 0.3, 1],
+                  ease: EASING.cinematic,
                }}
             >
                {children}

--- a/src/components/ui/GlassCard.tsx
+++ b/src/components/ui/GlassCard.tsx
@@ -66,7 +66,7 @@ const GlassCard = ({
          opacity: 1,
          background: `radial-gradient(
         350px circle at ${mousePos.x * 100}% ${mousePos.y * 100}%,
-        rgba(6, 182, 212, 0.08),
+        rgb(var(--ch-cyan) / 0.08),
         transparent 60%
       )`,
       };
@@ -87,7 +87,7 @@ const GlassCard = ({
             ...(!borderGlow || !isHovered
                ? {}
                : {
-                    borderColor: "rgba(6, 182, 212, 0.2)",
+                    borderColor: "rgb(var(--ch-cyan) / 0.2)",
                  }),
             ...style,
          }}
@@ -96,7 +96,10 @@ const GlassCard = ({
          onMouseLeave={handleMouseLeave}
          {...props}
       >
-         {/* Cursor-following glow overlay */}
+         {/* Cursor-following glow overlay -- one subtle radial highlight. The
+             previous per-mousemove conic-gradient border (mask-composite) was the
+             heaviest paint on hover and read as busy; a refined card uses a quiet
+             glow + a clean border-color shift (set on the wrapper) instead. */}
          {glow && (
             <div
                aria-hidden="true"
@@ -108,34 +111,6 @@ const GlassCard = ({
                   transition: "opacity 0.3s ease",
                   zIndex: 0,
                   ...glowStyle,
-               }}
-            />
-         )}
-
-         {/* Animated gradient border highlight on hover */}
-         {borderGlow && isHovered && !reducedMotion && (
-            <div
-               aria-hidden="true"
-               style={{
-                  position: "absolute",
-                  inset: -1,
-                  borderRadius: "inherit",
-                  pointerEvents: "none",
-                  zIndex: 0,
-                  background: `conic-gradient(
-              from ${Math.atan2(mousePos.y - 0.5, mousePos.x - 0.5) * (180 / Math.PI)}deg at ${mousePos.x * 100}% ${mousePos.y * 100}%,
-              rgba(6, 182, 212, 0.3),
-              transparent 40%,
-              rgba(168, 85, 247, 0.2),
-              transparent 70%,
-              rgba(6, 182, 212, 0.3)
-            )`,
-                  mask: "linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
-                  maskComposite: "exclude",
-                  WebkitMask:
-                     "linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
-                  WebkitMaskComposite: "xor",
-                  padding: 1,
                }}
             />
          )}

--- a/src/components/ui/InteractiveConstellation.tsx
+++ b/src/components/ui/InteractiveConstellation.tsx
@@ -181,9 +181,10 @@ const InteractiveConstellation = () => {
       const parkPointer = () => setPointer(OFFSCREEN, OFFSCREEN);
       // Pause the loop when the tab is hidden to save battery.
       const onVisibility = () => {
-         if (document.hidden) {
-            globalThis.cancelAnimationFrame(rafId);
-         } else {
+         // Always cancel first -- a spurious "visible" event while the loop is
+         // already running would otherwise stack a second rAF loop.
+         globalThis.cancelAnimationFrame(rafId);
+         if (!document.hidden) {
             rafId = globalThis.requestAnimationFrame(step);
          }
       };

--- a/src/components/ui/KeyboardNav.tsx
+++ b/src/components/ui/KeyboardNav.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useCallback } from "react";
+import { useLenis } from "lenis/react";
 
 const SECTIONS = [
    "hero",
@@ -14,6 +15,7 @@ const SECTIONS = [
 ];
 
 const KeyboardNav = () => {
+   const lenis = useLenis();
    const getCurrentSectionIndex = useCallback((): number => {
       const scrollY = window.scrollY;
       const windowHeight = window.innerHeight;
@@ -30,20 +32,34 @@ const KeyboardNav = () => {
       return 0;
    }, []);
 
-   const scrollToSection = useCallback((id: string) => {
-      const el = document.getElementById(id);
-      if (el) el.scrollIntoView({ behavior: "smooth" });
-   }, []);
+   const scrollToSection = useCallback(
+      (id: string) => {
+         const el = document.getElementById(id);
+         if (!el) return;
+         if (lenis) lenis.scrollTo(el, { offset: -64 });
+         else el.scrollIntoView();
+      },
+      [lenis],
+   );
 
    const handleKeyDown = useCallback(
       (e: KeyboardEvent) => {
-         // Ignore when typing in input fields
-         const tag = (e.target as HTMLElement).tagName;
+         // Don't hijack key combos (Ctrl/Cmd/Alt) -- those belong to the browser/OS.
+         if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+         // Ignore when typing in a field OR when focus is on any interactive
+         // control (button/link/etc) -- bare-key shortcuts must not fire while a
+         // control is focused (WCAG 2.1.4 Character Key Shortcuts).
+         const target = e.target as HTMLElement;
+         const tag = target.tagName;
          if (
             tag === "INPUT" ||
             tag === "TEXTAREA" ||
             tag === "SELECT" ||
-            (e.target as HTMLElement).isContentEditable
+            tag === "BUTTON" ||
+            tag === "A" ||
+            target.isContentEditable ||
+            target.closest("[role], button, a[href]")
          )
             return;
 

--- a/src/components/ui/ModalHeaderShell.tsx
+++ b/src/components/ui/ModalHeaderShell.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { motion } from "motion/react";
 import { X } from "lucide-react";
-import { TEXT_SECONDARY } from "@/constants/theme";
+import { TEXT_SECONDARY, GLASS_BORDER, EASING } from "@/constants/theme";
 
 interface ModalHeaderShellProps {
    isMobile: boolean;
@@ -9,8 +9,6 @@ interface ModalHeaderShellProps {
    closeLabel: string;
    children: ReactNode;
 }
-
-const EXPO_EASE = [0.16, 1, 0.3, 1] as const;
 
 /**
  * Shared sticky header frame used by ExperienceModal and ProjectModal.
@@ -27,7 +25,7 @@ const ModalHeaderShell = ({
    <motion.div
       initial={{ opacity: 0, y: -20 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ delay: 0.1, duration: 0.4, ease: EXPO_EASE }}
+      transition={{ delay: 0.1, duration: 0.4, ease: EASING.cinematic }}
       style={{
          position: "sticky",
          top: 0,
@@ -36,7 +34,7 @@ const ModalHeaderShell = ({
          background: "rgba(12,12,28,0.9)",
          backdropFilter: "blur(20px)",
          WebkitBackdropFilter: "blur(20px)",
-         borderBottom: "1px solid rgba(255,255,255,0.06)",
+         borderBottom: `1px solid ${GLASS_BORDER}`,
       }}
    >
       <div style={{ position: "relative" }}>

--- a/src/components/ui/ModalShell.tsx
+++ b/src/components/ui/ModalShell.tsx
@@ -83,7 +83,7 @@ const ModalShell = ({
                      background:
                         "linear-gradient(180deg, rgba(15,15,30,0.98) 0%, rgba(8,8,20,0.99) 100%)",
                      boxShadow:
-                        "0 30px 80px rgba(0,0,0,0.6), 0 0 60px rgba(6,182,212,0.04)",
+                        "0 30px 80px rgba(0,0,0,0.6), 0 0 60px rgb(var(--ch-cyan) / 0.04)",
                   }}
                >
                   {children}

--- a/src/components/ui/NodeDiagram.tsx
+++ b/src/components/ui/NodeDiagram.tsx
@@ -1,5 +1,10 @@
 import { motion } from "motion/react";
-import { MONO_FONT, TEXT_MUTED, GLASS_PANEL_STYLE } from "@/constants/theme";
+import {
+   MONO_FONT,
+   TEXT_MUTED,
+   GLASS_PANEL_STYLE,
+   EASING,
+} from "@/constants/theme";
 import {
    PANEL_INITIAL,
    PANEL_VISIBLE,
@@ -91,7 +96,7 @@ const NodeDiagram = ({
                         transition={{
                            delay: 0.4 + i * 0.15,
                            duration: 1,
-                           ease: [0.16, 1, 0.3, 1],
+                           ease: EASING.cinematic,
                         }}
                      />
                   );

--- a/src/components/ui/PreloaderContent.tsx
+++ b/src/components/ui/PreloaderContent.tsx
@@ -1,5 +1,5 @@
 import { motion } from "motion/react";
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, CYAN, PURPLE, TEXT_MUTED } from "@/constants/theme";
 
 interface PreloaderContentProps {
    displayProgress: number;
@@ -45,7 +45,7 @@ const PreloaderContent = ({ displayProgress }: PreloaderContentProps) => {
                fontSize: 48,
                fontWeight: 700,
                fontFamily: MONO_FONT,
-               color: "#06b6d4",
+               color: CYAN,
                letterSpacing: "0.05em",
                textShadow:
                   "0 0 30px rgba(6,182,212,0.5), 0 0 60px rgba(6,182,212,0.25)",
@@ -71,7 +71,7 @@ const PreloaderContent = ({ displayProgress }: PreloaderContentProps) => {
             <motion.div
                style={{
                   height: "100%",
-                  background: "linear-gradient(90deg, #06b6d4, #a855f7)",
+                  background: `linear-gradient(90deg, ${CYAN}, ${PURPLE})`,
                   borderRadius: 4,
                }}
                initial={{ width: "0%" }}
@@ -87,7 +87,7 @@ const PreloaderContent = ({ displayProgress }: PreloaderContentProps) => {
             style={{
                fontFamily: MONO_FONT,
                fontSize: 12,
-               color: "#6e6e90",
+               color: TEXT_MUTED,
                position: "relative",
                zIndex: 1,
             }}

--- a/src/components/ui/ScrollProgress.tsx
+++ b/src/components/ui/ScrollProgress.tsx
@@ -1,4 +1,5 @@
 import { motion, useScroll, useSpring } from "motion/react";
+import { CYAN, PURPLE } from "@/constants/theme";
 
 const ScrollProgress = () => {
    const { scrollYProgress } = useScroll();
@@ -16,7 +17,7 @@ const ScrollProgress = () => {
             left: 0,
             right: 0,
             height: 3,
-            background: "linear-gradient(90deg, #06b6d4, #a855f7)",
+            background: `linear-gradient(90deg, ${CYAN}, ${PURPLE})`,
             transformOrigin: "0%",
             scaleX,
             zIndex: 100,

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,6 +1,13 @@
 import { motion } from "motion/react";
 import { fadeInUp, lineGrow } from "@utils/animations";
-import { MONO_FONT } from "@/constants/theme";
+import {
+   MONO_FONT,
+   CYAN,
+   PURPLE,
+   TEXT_MUTED,
+   GLASS_BG,
+   GLASS_BORDER,
+} from "@/constants/theme";
 import ScrollRevealText from "@components/ui/ScrollRevealText";
 
 interface Props {
@@ -22,7 +29,7 @@ const SectionHeader = ({ title, subtitle }: Props) => {
          variants={fadeInUp}
          initial="hidden"
          whileInView="visible"
-         viewport={{ margin: "0px 0px -100px 0px" }}
+         viewport={{ once: true, margin: "0px 0px -100px 0px" }}
       >
          {subtitle && (
             <span
@@ -32,16 +39,16 @@ const SectionHeader = ({ title, subtitle }: Props) => {
                   gap: 8,
                   fontFamily: MONO_FONT,
                   fontSize: 14,
-                  color: "#6e6e90",
-                  backgroundColor: "rgba(255, 255, 255, 0.03)",
+                  color: TEXT_MUTED,
+                  backgroundColor: GLASS_BG,
                   backdropFilter: "blur(12px)",
                   WebkitBackdropFilter: "blur(12px)",
-                  border: "1px solid rgba(255, 255, 255, 0.06)",
+                  border: `1px solid ${GLASS_BORDER}`,
                   borderRadius: 9999,
                   padding: "4px 16px",
                }}
             >
-               <span style={{ color: "#06b6d4" }}>{">"}</span>
+               <span style={{ color: CYAN }}>{">"}</span>
                <ScrollRevealText text={subtitle} />
             </span>
          )}
@@ -61,12 +68,12 @@ const SectionHeader = ({ title, subtitle }: Props) => {
                width: 80,
                borderRadius: 9999,
                marginTop: 4,
-               background: "linear-gradient(to right, #06b6d4, #a855f7)",
+               background: `linear-gradient(to right, ${CYAN}, ${PURPLE})`,
             }}
             variants={lineGrow}
             initial="hidden"
             whileInView="visible"
-            viewport={{}}
+            viewport={{ once: true }}
          />
       </motion.div>
    );

--- a/src/components/ui/ShootingStars.tsx
+++ b/src/components/ui/ShootingStars.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { motion } from "motion/react";
 import useReducedMotion from "@hooks/useReducedMotion";
+import useBreakpoint from "@hooks/useBreakpoint";
 import { cryptoRandom } from "@utils/random";
 
 interface Streak {
@@ -16,9 +17,10 @@ interface Streak {
 }
 
 const STREAK_COUNT = 10;
+const STREAK_COUNT_MOBILE = 5;
 
-const generateStreaks = (): Streak[] =>
-   Array.from({ length: STREAK_COUNT }, (_, i) => ({
+const generateStreaks = (count: number): Streak[] =>
+   Array.from({ length: count }, (_, i) => ({
       id: i,
       startX: -10 + cryptoRandom() * 60,
       startY: cryptoRandom() * 70,
@@ -32,7 +34,12 @@ const generateStreaks = (): Streak[] =>
 
 const ShootingStars = () => {
    const reducedMotion = useReducedMotion();
-   const streaks = useMemo(() => generateStreaks(), []);
+   const { isMobile } = useBreakpoint();
+   // Fewer animating streaks on phones to ease GPU load; motion stays visible.
+   const streaks = useMemo(
+      () => generateStreaks(isMobile ? STREAK_COUNT_MOBILE : STREAK_COUNT),
+      [isMobile],
+   );
 
    if (reducedMotion) return null;
 

--- a/src/components/ui/SystemStatus.tsx
+++ b/src/components/ui/SystemStatus.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { motion } from "motion/react";
 import { Server, Eye } from "lucide-react";
 import { getSiteConfig } from "@data/dataLoader";
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, TEXT_SECONDARY, CYAN, GREEN } from "@/constants/theme";
 import useBreakpoint from "@hooks/useBreakpoint";
 
 const SystemStatus = () => {
@@ -47,7 +47,7 @@ const SystemStatus = () => {
          }}
          whileHover={{ y: -2, borderColor: "rgba(34, 197, 94, 0.3)" }}
       >
-         <Server size={14} color="#22c55e" />
+         <Server size={14} color={GREEN} />
 
          <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
             <div
@@ -65,7 +65,7 @@ const SystemStatus = () => {
                      height: "100%",
                      width: "100%",
                      borderRadius: "50%",
-                     backgroundColor: "#22c55e",
+                     backgroundColor: GREEN,
                      opacity: 0.75,
                      animation: "ping 1.5s cubic-bezier(0, 0, 0.2, 1) infinite",
                   }}
@@ -77,7 +77,7 @@ const SystemStatus = () => {
                      borderRadius: "50%",
                      height: 8,
                      width: 8,
-                     backgroundColor: "#22c55e",
+                     backgroundColor: GREEN,
                   }}
                />
             </div>
@@ -85,7 +85,7 @@ const SystemStatus = () => {
                style={{
                   fontFamily: MONO_FONT,
                   fontSize: 11,
-                  color: "#a5a5c0",
+                  color: TEXT_SECONDARY,
                   fontWeight: 500,
                }}
             >
@@ -101,12 +101,12 @@ const SystemStatus = () => {
             }}
          />
          <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
-            <Eye size={12} color="#06b6d4" />
+            <Eye size={12} color={CYAN} />
             <span
                style={{
                   fontFamily: MONO_FONT,
                   fontSize: 11,
-                  color: "#06b6d4",
+                  color: CYAN,
                   fontWeight: 600,
                }}
             >

--- a/src/components/ui/TechTag.tsx
+++ b/src/components/ui/TechTag.tsx
@@ -1,4 +1,4 @@
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, CYAN } from "@/constants/theme";
 
 interface TechTagProps {
    label: string;
@@ -6,7 +6,7 @@ interface TechTagProps {
    size?: number;
 }
 
-const TechTag = ({ label, accent = "#06b6d4", size = 11 }: TechTagProps) => (
+const TechTag = ({ label, accent = CYAN, size = 11 }: TechTagProps) => (
    <span
       style={{
          fontFamily: MONO_FONT,

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "motion/react";
 import { CheckCircle, XCircle, X } from "lucide-react";
+import { GREEN, RED, TEXT_PRIMARY, TEXT_MUTED } from "@/constants/theme";
 
 interface ToastProps {
    message: string;
@@ -11,15 +12,15 @@ interface ToastProps {
 
 const TOAST_COLORS = {
    success: {
-      accent: "#22c55e",
-      bg: "rgba(34, 197, 94, 0.08)",
-      border: "rgba(34, 197, 94, 0.15)",
+      accent: GREEN,
+      bg: "rgb(var(--ch-green) / 0.08)",
+      border: "rgb(var(--ch-green) / 0.15)",
       icon: CheckCircle,
    },
    error: {
-      accent: "#ef4444",
-      bg: "rgba(239, 68, 68, 0.08)",
-      border: "rgba(239, 68, 68, 0.15)",
+      accent: RED,
+      bg: "rgb(var(--ch-red) / 0.08)",
+      border: "rgb(var(--ch-red) / 0.15)",
       icon: XCircle,
    },
 };
@@ -48,7 +49,7 @@ const Toast = ({ message, type = "success", visible, onClose }: ToastProps) => {
                   gap: 12,
                   padding: "12px 20px",
                   borderRadius: 12,
-                  background: "rgba(15, 15, 35, 0.7)",
+                  background: "rgb(var(--ch-glass) / 0.7)",
                   backdropFilter: "blur(24px)",
                   WebkitBackdropFilter: "blur(24px)",
                   border: `1px solid ${config.border}`,
@@ -69,7 +70,7 @@ const Toast = ({ message, type = "success", visible, onClose }: ToastProps) => {
                   style={{
                      fontSize: 14,
                      fontWeight: 500,
-                     color: "#eeeef5",
+                     color: TEXT_PRIMARY,
                      flex: 1,
                   }}
                >
@@ -84,7 +85,7 @@ const Toast = ({ message, type = "success", visible, onClose }: ToastProps) => {
                         borderRadius: 6,
                         border: "none",
                         background: "rgba(255,255,255,0.05)",
-                        color: "#6e6e90",
+                        color: TEXT_MUTED,
                         cursor: "pointer",
                         display: "flex",
                         alignItems: "center",
@@ -93,10 +94,10 @@ const Toast = ({ message, type = "success", visible, onClose }: ToastProps) => {
                         flexShrink: 0,
                      }}
                      onMouseEnter={(e: React.MouseEvent<HTMLButtonElement>) => {
-                        e.currentTarget.style.color = "#eeeef5";
+                        e.currentTarget.style.color = TEXT_PRIMARY;
                      }}
                      onMouseLeave={(e: React.MouseEvent<HTMLButtonElement>) => {
-                        e.currentTarget.style.color = "#6e6e90";
+                        e.currentTarget.style.color = TEXT_MUTED;
                      }}
                      aria-label="Dismiss"
                   >

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -8,7 +8,6 @@ export const PURPLE = "#a855f7";
 export const GREEN = "#22c55e";
 export const AMBER = "#f59e0b";
 export const PINK = "#ec4899";
-export const BLUE = "#007bff";
 export const INDIGO = "#6366f1";
 export const ORANGE = "#f97316";
 export const RED = "#ef4444";
@@ -20,7 +19,9 @@ export const MEDAL_BRONZE = "#d97706";
 
 export const TEXT_PRIMARY = "#eeeef5";
 export const TEXT_SECONDARY = "#a5a5c0";
-export const TEXT_MUTED = "#6e6e90";
+// Lightened from #6e6e90 to clear WCAG 1.4.3 (4.5:1) for small informational
+// text on the dark glass backgrounds. Still reads as low-emphasis vs SECONDARY.
+export const TEXT_MUTED = "#8888a8";
 
 export const GLASS_BORDER = "rgba(255, 255, 255, 0.06)";
 export const GLASS_BG = "rgba(255, 255, 255, 0.03)";
@@ -31,6 +32,8 @@ export const MONO_FONT = "JetBrains Mono, ui-monospace, monospace";
 // ===== Layout =====
 export const MAX_WIDTH = 1152;
 export const MAX_WIDTH_NARROW = 960;
+export const MAX_WIDTH_WIDE = 1024; // GitHub calendar section
+export const MAX_WIDTH_FORM = 896; // Contact form + cards
 
 // ===== Responsive Breakpoints =====
 // Align with Tailwind defaults -- single source of truth for media queries.

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -44,6 +44,14 @@ const useFocusTrap = <T extends HTMLElement>(
          const first = nodes[0];
          const last = nodes[nodes.length - 1];
          const active = document.activeElement as HTMLElement | null;
+         // If focus has escaped the container (e.g. landed on the backdrop or
+         // body), pull it back in rather than letting Tab walk into the page
+         // behind the modal.
+         if (!container.contains(active)) {
+            (e.shiftKey ? last : first)?.focus();
+            e.preventDefault();
+            return;
+         }
          if (e.shiftKey && active === first) {
             last?.focus();
             e.preventDefault();

--- a/src/index.css
+++ b/src/index.css
@@ -17,7 +17,8 @@
 
    --color-text-primary: #eeeef5;
    --color-text-secondary: #a5a5c0;
-   --color-text-muted: #6e6e90;
+   /* Lightened from #6e6e90 for WCAG 1.4.3 (4.5:1) on dark glass surfaces. */
+   --color-text-muted: #8888a8;
 
    --color-accent-cyan: #06b6d4;
    --color-accent-purple: #a855f7;
@@ -36,6 +37,7 @@
    --ch-pink: 236 72 153;
    --ch-amber: 245 158 11;
    --ch-green: 34 197 94;
+   --ch-red: 239 68 68;
    --ch-indigo: 99 102 241;
    --ch-white: 255 255 255;
    --ch-black: 0 0 0;
@@ -57,9 +59,14 @@
 }
 
 html {
-   scroll-behavior: smooth;
+   /* Lenis owns smooth scrolling; CSS smooth here would double-drive programmatic
+      scrolls (scrollIntoView) and fight it. Keep auto. */
+   scroll-behavior: auto;
    -webkit-font-smoothing: antialiased;
    -moz-osx-font-smoothing: grayscale;
+   /* Always reserve the scrollbar gutter so opening a modal (which locks body
+      scroll) doesn't shift the page wider. */
+   scrollbar-gutter: stable;
 }
 
 body {
@@ -68,6 +75,9 @@ body {
    color: var(--color-text-primary);
    line-height: 1.7;
    overflow-x: hidden;
+   /* Stop iOS rubber-band / Android scroll-chaining from fighting Lenis at the
+      page extremes. */
+   overscroll-behavior-y: none;
 }
 
 /* Scrollbar */
@@ -98,6 +108,27 @@ body {
 :focus-visible {
    outline: 2px solid rgb(var(--ch-cyan) / 0.5);
    outline-offset: 2px;
+}
+
+/* Skip to content -- visible only when focused (WCAG 2.4.1 Bypass Blocks) */
+.skip-link {
+   position: fixed;
+   top: 8px;
+   left: 8px;
+   z-index: 1000;
+   padding: 10px 18px;
+   border-radius: 10px;
+   background: var(--color-bg-card);
+   color: var(--color-text-primary);
+   border: 1px solid rgb(var(--ch-cyan) / 0.4);
+   font-size: 0.875rem;
+   font-weight: 600;
+   transform: translateY(-150%);
+   transition: transform 0.2s ease;
+}
+
+.skip-link:focus {
+   transform: translateY(0);
 }
 
 /* Links */
@@ -289,6 +320,10 @@ img {
 
 /* ===== Gradient Text ===== */
 .gradient-text {
+   /* Solid fallback first -- if background-clip:text fails to paint (forced
+      colors, some print-to-PDF paths) the text stays readable instead of going
+      invisible. The transparent fill only applies where clip works. */
+   color: var(--color-accent-cyan);
    background: linear-gradient(
       135deg,
       var(--color-accent-cyan),
@@ -300,6 +335,7 @@ img {
 }
 
 .gradient-text-vivid {
+   color: rgb(var(--ch-cyan-light));
    background: linear-gradient(
       135deg,
       rgb(var(--ch-cyan-light)),
@@ -442,8 +478,8 @@ img {
 /* ===== Glass Card ===== */
 .glass-card {
    background: rgb(var(--ch-glass) / 0.5);
-   backdrop-filter: blur(20px);
-   -webkit-backdrop-filter: blur(20px);
+   backdrop-filter: blur(10px);
+   -webkit-backdrop-filter: blur(10px);
    border: 1px solid rgb(var(--ch-white) / 0.06);
    border-radius: 16px;
    transition:
@@ -484,10 +520,17 @@ img {
    background-color: transparent;
 }
 
+/* Darker band: a semi-opaque gradient instead of backdrop-filter. These are
+   full-width bands taller than the viewport; a backdrop blur here re-samples the
+   animated aurora/3D backdrop every scroll frame (the dominant fast-scroll jank
+   source). The gradient bakes into the layer and composites for free -- the faint
+   aurora still shows through, only the per-frame blur-of-a-moving-backdrop is gone. */
 .section-darker {
-   background: rgb(var(--ch-bg-sec) / 0.25);
-   backdrop-filter: blur(8px);
-   -webkit-backdrop-filter: blur(8px);
+   background: linear-gradient(
+      180deg,
+      rgb(var(--ch-bg-sec) / 0.38),
+      rgb(var(--ch-bg-sec) / 0.2)
+   );
 }
 
 /* ===== Gradient Buttons ===== */
@@ -560,8 +603,6 @@ img {
       background 0.25s ease,
       border-color 0.25s ease,
       box-shadow 0.25s ease;
-   backdrop-filter: blur(8px);
-   -webkit-backdrop-filter: blur(8px);
 }
 
 .tag-cyan {
@@ -627,8 +668,6 @@ img {
       box-shadow 0.3s ease,
       transform 0.3s ease;
    cursor: default;
-   backdrop-filter: blur(8px);
-   -webkit-backdrop-filter: blur(8px);
 }
 
 .skill-tag:hover {
@@ -637,6 +676,11 @@ img {
    background: rgb(var(--ch-cyan) / 0.08);
    box-shadow: 0 0 20px rgb(var(--ch-cyan) / 0.08);
    transform: translateY(-1px);
+}
+
+/* Tap feedback -- the only motion most touch users see on these chips. */
+.skill-tag:active {
+   transform: scale(0.96);
 }
 
 /* ===== Form Input ===== */
@@ -667,6 +711,17 @@ img {
    box-shadow:
       0 0 0 3px rgb(var(--ch-cyan) / 0.08),
       0 0 25px rgb(var(--ch-cyan) / 0.06);
+}
+
+.form-input--error {
+   border-color: rgb(var(--ch-red) / 0.5);
+}
+
+.form-input--error:focus {
+   border-color: rgb(var(--ch-red) / 0.6);
+   box-shadow:
+      0 0 0 3px rgb(var(--ch-red) / 0.08),
+      0 0 25px rgb(var(--ch-red) / 0.06);
 }
 
 /* ===== Skeleton Loading ===== */
@@ -760,7 +815,8 @@ img {
       transform: none;
    }
 
-   .skill-tag:hover {
+   .skill-tag:hover,
+   .skill-tag:active {
       transform: none;
    }
 

--- a/src/pages/about/About.tsx
+++ b/src/pages/about/About.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { motion } from "motion/react";
 import { getAbout, getStatistics } from "@data/dataLoader";
 import { staggerContainer, fadeInLeft, fadeInRight } from "@utils/animations";
-import { GREEN, MONO_FONT } from "@/constants/theme";
+import { GREEN, MONO_FONT, TEXT_PRIMARY, MAX_WIDTH } from "@/constants/theme";
 import DevAvatar from "@components/ui/DevAvatar";
 import useBreakpoint from "@hooks/useBreakpoint";
 import PageSection from "@components/layout/PageSection";
@@ -29,7 +29,7 @@ const About = () => {
 
    return (
       <PageSection id="about" title="About Me" subtitle="Get to know me">
-         <div style={{ maxWidth: 1152, margin: "0 auto" }}>
+         <div style={{ maxWidth: MAX_WIDTH, margin: "0 auto" }}>
             <motion.div
                style={{
                   display: "grid",
@@ -95,7 +95,7 @@ const About = () => {
                      style={{
                         fontSize: isMobile ? 22 : 28,
                         fontWeight: 700,
-                        color: "#eeeef5",
+                        color: TEXT_PRIMARY,
                         marginBottom: 16,
                         lineHeight: 1.2,
                      }}

--- a/src/pages/about/HighlightCard.tsx
+++ b/src/pages/about/HighlightCard.tsx
@@ -2,12 +2,13 @@ import { motion } from "motion/react";
 import { Briefcase, GraduationCap, Rocket, Trophy } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { staggerItem } from "@utils/animations";
+import { CYAN, PURPLE, GREEN, AMBER, TEXT_SECONDARY } from "@/constants/theme";
 
 const HIGHLIGHT_ICONS: { Icon: LucideIcon; color: string }[] = [
-   { Icon: Briefcase, color: "#06b6d4" },
-   { Icon: GraduationCap, color: "#a855f7" },
-   { Icon: Rocket, color: "#22c55e" },
-   { Icon: Trophy, color: "#f59e0b" },
+   { Icon: Briefcase, color: CYAN },
+   { Icon: GraduationCap, color: PURPLE },
+   { Icon: Rocket, color: GREEN },
+   { Icon: Trophy, color: AMBER },
 ];
 
 interface HighlightCardProps {
@@ -53,7 +54,7 @@ const HighlightCard = ({ text, index, isMobile }: HighlightCardProps) => {
          </div>
          <p
             style={{
-               color: "#cbd5e1",
+               color: TEXT_SECONDARY,
                fontSize: isMobile ? 13 : 14,
                lineHeight: 1.7,
                margin: 0,

--- a/src/pages/about/StatCounter.tsx
+++ b/src/pages/about/StatCounter.tsx
@@ -1,5 +1,6 @@
 import { motion } from "motion/react";
 import { staggerContainer, rotateInUp } from "@utils/animations";
+import { TEXT_MUTED } from "@/constants/theme";
 import AnimatedCounter from "@components/ui/AnimatedCounter";
 
 const STAT_LABELS: Record<string, string> = {
@@ -22,14 +23,14 @@ const StatCounter = ({ statEntries, isMobile }: StatCounterProps) => (
          display: "grid",
          gridTemplateColumns: isMobile
             ? "repeat(2, 1fr)"
-            : `repeat(${statEntries.length}, 1fr)`,
+            : "repeat(auto-fit, minmax(140px, 1fr))",
          gap: isMobile ? 12 : 16,
-         marginTop: isMobile ? 40 : 56,
+         marginTop: isMobile ? 40 : 48,
       }}
       variants={staggerContainer}
       initial="hidden"
       whileInView="visible"
-      viewport={{ margin: "0px 0px -100px 0px" }}
+      viewport={{ once: true, margin: "0px 0px -100px 0px" }}
    >
       {statEntries.map(([key, value]) => (
          <motion.div
@@ -44,7 +45,7 @@ const StatCounter = ({ statEntries, isMobile }: StatCounterProps) => (
             <AnimatedCounter value={value} />
             <p
                style={{
-                  color: "#6e6e90",
+                  color: TEXT_MUTED,
                   fontSize: isMobile ? 10 : 11,
                   textTransform: "uppercase",
                   letterSpacing: "0.06em",

--- a/src/pages/achievement/Achievement.tsx
+++ b/src/pages/achievement/Achievement.tsx
@@ -5,6 +5,7 @@ import {
    getAchievements,
 } from "@data/dataLoader";
 import PageSection from "@components/layout/PageSection";
+import { MAX_WIDTH } from "@/constants/theme";
 import { LEVEL_ORDER } from "./achievementConstants";
 import CertBadgeShowcase from "./CertBadgeShowcase";
 import BadgesSection from "./BadgesSection";
@@ -32,7 +33,7 @@ const Achievement = () => {
       >
          <div
             style={{
-               maxWidth: 1152,
+               maxWidth: MAX_WIDTH,
                margin: "0 auto",
                display: "flex",
                flexDirection: "column",

--- a/src/pages/achievement/BadgesSection.tsx
+++ b/src/pages/achievement/BadgesSection.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import { BookOpen } from "lucide-react";
 import type { LearningBadge } from "@/types";
 import { fadeInUp } from "@utils/animations";
+import { PURPLE, TEXT_MUTED, TEXT_PRIMARY } from "@/constants/theme";
 import useBreakpoint from "@hooks/useBreakpoint";
 import CertBadge from "./CertBadge";
 
@@ -42,13 +43,13 @@ const BadgesSection = ({ badges }: BadgesSectionProps) => {
                   justifyContent: "center",
                }}
             >
-               <BookOpen style={{ width: 18, height: 18, color: "#a855f7" }} />
+               <BookOpen style={{ width: 18, height: 18, color: PURPLE }} />
             </div>
             <h3
                style={{
                   fontSize: 20,
                   fontWeight: 700,
-                  color: "#eeeef5",
+                  color: TEXT_PRIMARY,
                }}
             >
                Learning & Training
@@ -57,7 +58,7 @@ const BadgesSection = ({ badges }: BadgesSectionProps) => {
                style={{
                   fontSize: 12,
                   fontWeight: 600,
-                  color: "#6e6e90",
+                  color: TEXT_MUTED,
                   padding: "2px 8px",
                   borderRadius: 6,
                   background: "rgba(255,255,255,0.04)",

--- a/src/pages/achievement/CertBadge.tsx
+++ b/src/pages/achievement/CertBadge.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { motion } from "motion/react";
-import { CYAN, PURPLE, TEXT_PRIMARY, MONO_FONT } from "@/constants/theme";
+import { CYAN, EASING, PURPLE, TEXT_PRIMARY, MONO_FONT } from "@/constants/theme";
+import { credlyThumb } from "@utils/credlyThumb";
 
 interface CertBadgeProps {
    name: string;
@@ -41,7 +42,7 @@ const CertBadge = ({
          transition={{
             delay: entranceDelay,
             duration: 0.7,
-            ease: [0.16, 1, 0.3, 1],
+            ease: EASING.cinematic,
          }}
          onHoverStart={() => setIsHovered(true)}
          onHoverEnd={() => setIsHovered(false)}
@@ -83,9 +84,11 @@ const CertBadge = ({
                }}
             />
             <img
-               src={imageUrl}
+               src={credlyThumb(imageUrl)}
                alt={name}
                loading="lazy"
+               width={size}
+               height={size}
                style={{
                   width: size,
                   height: size,

--- a/src/pages/achievement/CertBadgeShowcase.tsx
+++ b/src/pages/achievement/CertBadgeShowcase.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import { ShieldCheck } from "lucide-react";
 import { fadeInUp } from "@utils/animations";
 import type { Certification } from "@/types";
+import { CYAN, TEXT_MUTED, TEXT_PRIMARY } from "@/constants/theme";
 import useBreakpoint from "@hooks/useBreakpoint";
 import CertBadge from "./CertBadge";
 
@@ -40,14 +41,14 @@ const CertBadgeShowcase = ({ certifications }: CertBadgeShowcaseProps) => {
                }}
             >
                <ShieldCheck
-                  style={{ width: 18, height: 18, color: "#06b6d4" }}
+                  style={{ width: 18, height: 18, color: CYAN }}
                />
             </div>
             <h3
                style={{
                   fontSize: 20,
                   fontWeight: 700,
-                  color: "#eeeef5",
+                  color: TEXT_PRIMARY,
                }}
             >
                Industry Certifications
@@ -56,7 +57,7 @@ const CertBadgeShowcase = ({ certifications }: CertBadgeShowcaseProps) => {
                style={{
                   fontSize: 12,
                   fontWeight: 600,
-                  color: "#6e6e90",
+                  color: TEXT_MUTED,
                   padding: "2px 8px",
                   borderRadius: 6,
                   background: "rgba(255,255,255,0.04)",

--- a/src/pages/achievement/CodingPlatformCard.tsx
+++ b/src/pages/achievement/CodingPlatformCard.tsx
@@ -1,7 +1,7 @@
 import { motion } from "motion/react";
 import { ArrowUpRight } from "lucide-react";
 import { fadeInUp } from "@utils/animations";
-import { MONO_FONT } from "@/constants/theme";
+import { CYAN, MONO_FONT, TEXT_MUTED } from "@/constants/theme";
 import AnimatedCounter from "@components/ui/AnimatedCounter";
 import { formatStatLabel, isNumericStat } from "./achievementConstants";
 
@@ -51,7 +51,7 @@ const CodingPlatformCard = ({ platform, stats }: CodingPlatformCardProps) => (
                      <span
                         className="glow-cyan-text"
                         style={{
-                           color: "#06b6d4",
+                           color: CYAN,
                            fontSize: "1.875rem",
                            fontWeight: 700,
                            fontFamily: MONO_FONT,
@@ -63,7 +63,7 @@ const CodingPlatformCard = ({ platform, stats }: CodingPlatformCardProps) => (
                   )}
                   <span
                      style={{
-                        color: "#6e6e90",
+                        color: TEXT_MUTED,
                         fontSize: 12,
                         textTransform: "uppercase",
                         letterSpacing: "0.05em",
@@ -91,7 +91,7 @@ const CodingPlatformCard = ({ platform, stats }: CodingPlatformCardProps) => (
                borderRadius: 10,
                fontSize: 12,
                fontWeight: 600,
-               color: "#06b6d4",
+               color: CYAN,
                border: "1px solid rgba(6,182,212,0.25)",
                background: "rgba(6,182,212,0.06)",
                textDecoration: "none",

--- a/src/pages/achievement/CodingPlatformsSection.tsx
+++ b/src/pages/achievement/CodingPlatformsSection.tsx
@@ -1,5 +1,6 @@
 import { motion } from "motion/react";
 import { staggerContainer, fadeInUp } from "@utils/animations";
+import { TEXT_PRIMARY } from "@/constants/theme";
 import CodingPlatformCard from "./CodingPlatformCard";
 
 interface CodingPlatformsSectionProps {
@@ -19,7 +20,7 @@ const CodingPlatformsSection = ({
             style={{
                fontSize: 20,
                fontWeight: 700,
-               color: "#eeeef5",
+               color: TEXT_PRIMARY,
                marginBottom: 24,
                textAlign: "center",
             }}

--- a/src/pages/achievement/CompetitionsSection.tsx
+++ b/src/pages/achievement/CompetitionsSection.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import { Trophy } from "lucide-react";
 import type { Achievement } from "@/types";
 import { fadeInUp } from "@utils/animations";
+import { AMBER, TEXT_MUTED, TEXT_PRIMARY } from "@/constants/theme";
 import useBreakpoint from "@hooks/useBreakpoint";
 import TrophyCard from "./TrophyCard";
 
@@ -40,13 +41,13 @@ const CompetitionsSection = ({ achievements }: CompetitionsSectionProps) => {
                   justifyContent: "center",
                }}
             >
-               <Trophy style={{ width: 18, height: 18, color: "#f59e0b" }} />
+               <Trophy style={{ width: 18, height: 18, color: AMBER }} />
             </div>
             <h3
                style={{
                   fontSize: 20,
                   fontWeight: 700,
-                  color: "#eeeef5",
+                  color: TEXT_PRIMARY,
                }}
             >
                Competitions & Awards
@@ -55,7 +56,7 @@ const CompetitionsSection = ({ achievements }: CompetitionsSectionProps) => {
                style={{
                   fontSize: 12,
                   fontWeight: 600,
-                  color: "#6e6e90",
+                  color: TEXT_MUTED,
                   padding: "2px 8px",
                   borderRadius: 6,
                   background: "rgba(255,255,255,0.04)",

--- a/src/pages/achievement/TrophyCard.tsx
+++ b/src/pages/achievement/TrophyCard.tsx
@@ -4,6 +4,7 @@ import type { Achievement } from "@/types";
 import {
    MONO_FONT,
    CYAN,
+   EASING,
    TEXT_PRIMARY,
    TEXT_SECONDARY,
    TEXT_MUTED,
@@ -55,8 +56,6 @@ const parsePlacement = (
    return { rank: "", event: title, color: TEXT_MUTED };
 };
 
-const EXPO_EASE = [0.16, 1, 0.3, 1] as const;
-
 const TrophyCard = ({ item, index }: TrophyCardProps) => {
    const { rank, event, color } = parsePlacement(item.title);
 
@@ -69,7 +68,7 @@ const TrophyCard = ({ item, index }: TrophyCardProps) => {
          transition={{
             delay: index * 0.08,
             duration: 0.7,
-            ease: EXPO_EASE,
+            ease: EASING.cinematic,
          }}
          whileHover={{
             y: -4,

--- a/src/pages/contact/Contact.tsx
+++ b/src/pages/contact/Contact.tsx
@@ -2,6 +2,7 @@ import { motion, AnimatePresence } from "motion/react";
 import Toast from "@components/ui/Toast";
 import { getContactOptions } from "@data/dataLoader";
 import { rotateInUp, staggerContainer } from "@utils/animations";
+import { MAX_WIDTH_FORM } from "@/constants/theme";
 import useBreakpoint from "@hooks/useBreakpoint";
 import PageSection from "@components/layout/PageSection";
 import ContactCard from "./ContactCard";
@@ -20,6 +21,7 @@ const Contact = () => {
       isLoading,
       toastVisible,
       showConfirmation,
+      sentName,
       handleChange,
       handleSubmit,
       dismissToast,
@@ -34,7 +36,7 @@ const Contact = () => {
       >
          <motion.div
             style={{
-               maxWidth: 896,
+               maxWidth: MAX_WIDTH_FORM,
                margin: "0 auto",
                display: "grid",
                gap: isMobile ? 24 : 32,
@@ -69,7 +71,7 @@ const Contact = () => {
                      >
                         <SendConfirmation
                            onReset={resetConfirmation}
-                           senderName={formData.name}
+                           senderName={sentName}
                         />
                      </motion.div>
                   ) : (
@@ -85,6 +87,7 @@ const Contact = () => {
                            formData={formData}
                            isLoading={isLoading}
                            isMobile={isMobile}
+                           status={status}
                            onChange={handleChange}
                            onSubmit={handleSubmit}
                         />

--- a/src/pages/contact/ContactCard.tsx
+++ b/src/pages/contact/ContactCard.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import { ArrowUpRight } from "lucide-react";
 import type { ContactOption } from "@/types";
 import { staggerItem } from "@utils/animations";
+import { TEXT_MUTED, TEXT_PRIMARY } from "@/constants/theme";
 import { getContactMeta } from "./contactConstants";
 
 interface ContactCardProps {
@@ -20,7 +21,7 @@ const ContactCard = ({ option, isMobile }: ContactCardProps) => {
          variants={staggerItem}
          className="glass-card"
          style={{
-            padding: isMobile ? "16px 14px" : "18px 20px",
+            padding: isMobile ? "16px 16px" : "16px 20px",
             display: "flex",
             alignItems: "center",
             gap: 12,
@@ -55,7 +56,7 @@ const ContactCard = ({ option, isMobile }: ContactCardProps) => {
          <div style={{ minWidth: 0, flex: 1 }}>
             <p
                style={{
-                  color: "#6e6e90",
+                  color: TEXT_MUTED,
                   fontSize: 11,
                   textTransform: "uppercase",
                   letterSpacing: "0.06em",
@@ -66,7 +67,7 @@ const ContactCard = ({ option, isMobile }: ContactCardProps) => {
             </p>
             <p
                style={{
-                  color: "#eeeef5",
+                  color: TEXT_PRIMARY,
                   fontSize: isMobile ? 13 : 14,
                   fontWeight: 500,
                   marginTop: 2,

--- a/src/pages/contact/ContactForm.tsx
+++ b/src/pages/contact/ContactForm.tsx
@@ -1,11 +1,14 @@
+import { motion } from "motion/react";
 import { Send } from "lucide-react";
-import type { FormData } from "./contactConstants";
+import { TEXT_SECONDARY, RED } from "@/constants/theme";
+import type { FormData, Status } from "./contactConstants";
 
 interface ContactFormProps {
    formRef: React.RefObject<HTMLFormElement | null>;
    formData: FormData;
    isLoading: boolean;
    isMobile: boolean;
+   status: Status;
    onChange: (
       e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
    ) => void;
@@ -16,7 +19,7 @@ const labelStyle: React.CSSProperties = {
    display: "block",
    fontSize: 12,
    fontWeight: 600,
-   color: "#a5a5c0",
+   color: TEXT_SECONDARY,
    textTransform: "uppercase",
    letterSpacing: "0.05em",
    marginBottom: 8,
@@ -27,9 +30,14 @@ const ContactForm = ({
    formData,
    isLoading,
    isMobile,
+   status,
    onChange,
    onSubmit,
-}: ContactFormProps) => (
+}: ContactFormProps) => {
+   // The only programmatic validation today is the email-pattern check, so an
+   // error status maps to the email field. Surface it inline + to AT.
+   const emailError = status.type === "error" ? status.message : "";
+   return (
    <form
       ref={formRef}
       onSubmit={onSubmit}
@@ -81,8 +89,23 @@ const ContactForm = ({
             value={formData.email}
             onChange={onChange}
             required
-            className="form-input"
+            className={`form-input${emailError ? " form-input--error" : ""}`}
+            aria-invalid={emailError ? true : undefined}
+            aria-describedby={emailError ? "contact-email-error" : undefined}
          />
+         {emailError && (
+            <p
+               id="contact-email-error"
+               role="alert"
+               style={{
+                  margin: "6px 2px 0",
+                  fontSize: 12,
+                  color: RED,
+               }}
+            >
+               {emailError}
+            </p>
+         )}
       </div>
 
       <div>
@@ -98,15 +121,18 @@ const ContactForm = ({
             onChange={onChange}
             required
             className="form-input"
-            style={{ resize: "none" }}
+            style={{ resize: "vertical" }}
          />
       </div>
 
-      <button
+      <motion.button
          type="submit"
          disabled={isLoading}
          className="btn-primary"
          aria-label={isLoading ? "Sending message..." : "Send message"}
+         aria-busy={isLoading}
+         whileHover={isLoading ? undefined : { scale: 1.02 }}
+         whileTap={isLoading ? undefined : { scale: 0.97 }}
          style={{
             width: "100%",
             display: "flex",
@@ -119,8 +145,7 @@ const ContactForm = ({
       >
          {isLoading ? (
             <div
-               role="status"
-               aria-label="Sending message"
+               aria-hidden="true"
                style={{
                   width: 20,
                   height: 20,
@@ -136,8 +161,9 @@ const ContactForm = ({
                Send Message
             </>
          )}
-      </button>
+      </motion.button>
    </form>
-);
+   );
+};
 
 export default ContactForm;

--- a/src/pages/contact/SendConfirmation.tsx
+++ b/src/pages/contact/SendConfirmation.tsx
@@ -24,6 +24,8 @@ const SendConfirmation = ({ onReset, senderName }: SendConfirmationProps) => {
    return (
       <div
          className="glass-card"
+         role="status"
+         aria-live="polite"
          style={{
             padding: "48px 32px",
             display: "flex",
@@ -47,8 +49,8 @@ const SendConfirmation = ({ onReset, senderName }: SendConfirmationProps) => {
                      gap: 8,
                      padding: "16px 24px",
                      borderRadius: 16,
-                     background: "rgba(6,182,212,0.06)",
-                     border: "1px solid rgba(6,182,212,0.15)",
+                     background: "rgb(var(--ch-cyan) / 0.06)",
+                     border: "1px solid rgb(var(--ch-cyan) / 0.15)",
                   }}
                >
                   {[0, 1, 2].map((dot) => (

--- a/src/pages/contact/useContactForm.ts
+++ b/src/pages/contact/useContactForm.ts
@@ -17,22 +17,15 @@ const useContactForm = () => {
    const [isLoading, setIsLoading] = useState(false);
    const [toastVisible, setToastVisible] = useState(false);
    const [showConfirmation, setShowConfirmation] = useState(false);
+   // Preserve the sender's name across the form reset so the success screen can
+   // still greet them -- formData is cleared in the same batch as showConfirmation.
+   const [sentName, setSentName] = useState("");
 
    useEffect(() => {
-      if (status.type) {
-         setToastVisible(true);
-         const hideTimer = setTimeout(() => {
-            setToastVisible(false);
-            clearTimerRef.current = setTimeout(
-               () => setStatus({ type: "", message: "" }),
-               300,
-            );
-         }, 5000);
-         return () => {
-            clearTimeout(hideTimer);
-            clearTimeout(clearTimerRef.current);
-         };
-      }
+      // Success is shown via the SendConfirmation screen, not a toast, so the
+      // only toast path is errors. Errors carry recovery instructions, so they
+      // stay until the user dismisses or edits a field (no auto-dismiss timer).
+      if (status.type === "error") setToastVisible(true);
    }, [status.type]);
 
    const handleChange = useCallback(
@@ -78,9 +71,17 @@ const useContactForm = () => {
             );
 
             if (result.status === 200) {
+               setSentName(formData.name);
                setShowConfirmation(true);
                setFormData({ name: "", email: "", message: "" });
                formRef.current.reset();
+            } else {
+               // EmailJS resolved with a non-200 status -- surface it instead of
+               // silently doing nothing.
+               setStatus({
+                  type: "error",
+                  message: "Failed to send message. Please try again.",
+               });
             }
          } catch {
             setStatus({
@@ -91,7 +92,7 @@ const useContactForm = () => {
             setIsLoading(false);
          }
       },
-      [emailConfig, formData.email],
+      [emailConfig, formData.email, formData.name],
    );
 
    const dismissToast = useCallback(() => {
@@ -113,6 +114,7 @@ const useContactForm = () => {
       isLoading,
       toastVisible,
       showConfirmation,
+      sentName,
       handleChange,
       handleSubmit,
       dismissToast,

--- a/src/pages/education/AnimatedTimelineTrack.tsx
+++ b/src/pages/education/AnimatedTimelineTrack.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { motion, useInView } from "motion/react";
+import { PURPLE } from "@/constants/theme";
 
 const AnimatedTimelineTrack = () => {
    const ref = useRef<HTMLDivElement>(null);
@@ -26,7 +27,7 @@ const AnimatedTimelineTrack = () => {
                width: 16,
                height: 16,
                borderRadius: "50%",
-               border: "2px solid #a855f7",
+               border: `2px solid ${PURPLE}`,
                backgroundColor: "rgba(6, 6, 16, 0.6)",
                marginTop: 4,
                position: "relative",
@@ -40,7 +41,7 @@ const AnimatedTimelineTrack = () => {
                   position: "absolute",
                   inset: 3,
                   borderRadius: "50%",
-                  backgroundColor: "#a855f7",
+                  backgroundColor: PURPLE,
                }}
             />
          </motion.div>

--- a/src/pages/education/Education.tsx
+++ b/src/pages/education/Education.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { motion } from "motion/react";
 import { getEducation } from "@data/dataLoader";
 import { staggerContainer } from "@utils/animations";
+import { MAX_WIDTH_NARROW } from "@/constants/theme";
 import useBreakpoint from "@hooks/useBreakpoint";
 import PageSection from "@components/layout/PageSection";
 import EducationCard from "./EducationCard";
@@ -15,7 +16,7 @@ const Education = () => {
          id="education"
          title="Education"
          subtitle="My academic journey"
-         maxWidth={960}
+         maxWidth={MAX_WIDTH_NARROW}
       >
          <motion.div variants={staggerContainer}>
             {education.map((item, index) => (

--- a/src/pages/education/EducationCard.tsx
+++ b/src/pages/education/EducationCard.tsx
@@ -3,7 +3,7 @@ import { MapPin } from "lucide-react";
 import type { Education } from "@/types";
 import { staggerItem, slideInLeft, slideInRight } from "@utils/animations";
 import { splitDateRange } from "@utils/dateRange";
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, PURPLE, TEXT_MUTED } from "@/constants/theme";
 import EducationCardContent from "./EducationCardContent";
 import AnimatedTimelineTrack from "./AnimatedTimelineTrack";
 
@@ -25,7 +25,7 @@ const EducationCard = ({ item, index, isMobile }: EducationCardProps) => {
                className="glass-card"
                style={{
                   padding: "20px 16px",
-                  borderLeft: "3px solid #a855f7",
+                  borderLeft: `3px solid ${PURPLE}`,
                }}
             >
                {/* Date + Location at top */}
@@ -42,7 +42,7 @@ const EducationCard = ({ item, index, isMobile }: EducationCardProps) => {
                         fontFamily: MONO_FONT,
                         fontSize: 12,
                         fontWeight: 600,
-                        color: "#a855f7",
+                        color: PURPLE,
                      }}
                   >
                      {splitDateRange(item.date).start}
@@ -52,7 +52,7 @@ const EducationCard = ({ item, index, isMobile }: EducationCardProps) => {
                         style={{
                            fontFamily: MONO_FONT,
                            fontSize: 11,
-                           color: "#6e6e90",
+                           color: TEXT_MUTED,
                         }}
                      >
                         — {splitDateRange(item.date).end}
@@ -61,7 +61,7 @@ const EducationCard = ({ item, index, isMobile }: EducationCardProps) => {
                   {item.location && (
                      <span
                         style={{
-                           color: "#6e6e90",
+                           color: TEXT_MUTED,
                            fontSize: 12,
                            display: "flex",
                            alignItems: "center",
@@ -97,7 +97,7 @@ const EducationCard = ({ item, index, isMobile }: EducationCardProps) => {
                   fontFamily: MONO_FONT,
                   fontSize: 12,
                   fontWeight: 600,
-                  color: "#a855f7",
+                  color: PURPLE,
                }}
             >
                {item.date.split(" - ")[0]}
@@ -107,7 +107,7 @@ const EducationCard = ({ item, index, isMobile }: EducationCardProps) => {
                   display: "block",
                   fontFamily: MONO_FONT,
                   fontSize: 11,
-                  color: "#6e6e90",
+                  color: TEXT_MUTED,
                   marginTop: 2,
                }}
             >
@@ -116,7 +116,7 @@ const EducationCard = ({ item, index, isMobile }: EducationCardProps) => {
             {item.location && (
                <p
                   style={{
-                     color: "#6e6e90",
+                     color: TEXT_MUTED,
                      fontSize: 12,
                      display: "flex",
                      alignItems: "center",

--- a/src/pages/education/EducationCardContent.tsx
+++ b/src/pages/education/EducationCardContent.tsx
@@ -1,5 +1,6 @@
 import { BookOpen } from "lucide-react";
 import type { Education } from "@/types";
+import { TEXT_MUTED } from "@/constants/theme";
 import EducationCardHeader from "./EducationCardHeader";
 import ExpandableExtras from "./ExpandableExtras";
 
@@ -24,7 +25,7 @@ const EducationCardContent = ({
                {item.department && (
                   <p
                      style={{
-                        color: "#6e6e90",
+                        color: TEXT_MUTED,
                         fontSize: 12,
                         display: "flex",
                         alignItems: "center",
@@ -36,12 +37,12 @@ const EducationCardContent = ({
                   </p>
                )}
                {item.board && (
-                  <p style={{ color: "#6e6e90", fontSize: 12, marginTop: 3 }}>
+                  <p style={{ color: TEXT_MUTED, fontSize: 12, marginTop: 3 }}>
                      {item.board}
                   </p>
                )}
                {item.field && (
-                  <p style={{ color: "#6e6e90", fontSize: 12, marginTop: 3 }}>
+                  <p style={{ color: TEXT_MUTED, fontSize: 12, marginTop: 3 }}>
                      {item.field}
                   </p>
                )}

--- a/src/pages/education/EducationCardHeader.tsx
+++ b/src/pages/education/EducationCardHeader.tsx
@@ -1,6 +1,6 @@
 import { GraduationCap } from "lucide-react";
 import type { Education } from "@/types";
-import { MONO_FONT } from "@/constants/theme";
+import { CYAN, GREEN, MONO_FONT, PURPLE, TEXT_PRIMARY } from "@/constants/theme";
 import AnimatedCounter from "@components/ui/AnimatedCounter";
 
 interface EducationCardHeaderProps {
@@ -24,13 +24,13 @@ const InstitutionRow = ({ institution }: { institution: string }) => (
             flexShrink: 0,
          }}
       >
-         <GraduationCap style={{ width: 14, height: 14, color: "#a855f7" }} />
+         <GraduationCap style={{ width: 14, height: 14, color: PURPLE }} />
       </div>
       <h3
          style={{
             fontSize: 20,
             fontWeight: 700,
-            color: "#eeeef5",
+            color: TEXT_PRIMARY,
             lineHeight: 1.2,
          }}
       >
@@ -64,7 +64,7 @@ const CgpaBadge = ({
       >
          <span
             style={{
-               color: "#22c55e",
+               color: GREEN,
                fontWeight: 700,
                fontSize: 16,
                fontFamily: MONO_FONT,
@@ -85,7 +85,7 @@ const EducationCardHeader = ({
       return (
          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
             <InstitutionRow institution={item.institution} />
-            <p style={{ color: "#06b6d4", fontWeight: 600, fontSize: 14 }}>
+            <p style={{ color: CYAN, fontWeight: 600, fontSize: 14 }}>
                {item.title}
             </p>
             <CgpaBadge item={item} isMobile={isMobile} />
@@ -106,7 +106,7 @@ const EducationCardHeader = ({
             <InstitutionRow institution={item.institution} />
             <p
                style={{
-                  color: "#06b6d4",
+                  color: CYAN,
                   fontWeight: 600,
                   fontSize: 14,
                   marginTop: 4,

--- a/src/pages/education/ExpandableExtras.tsx
+++ b/src/pages/education/ExpandableExtras.tsx
@@ -1,15 +1,20 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { Trophy, ChevronDown } from "lucide-react";
-import { AMBER, MONO_FONT, TEXT_MUTED } from "@/constants/theme";
+import {
+   AMBER,
+   EASING,
+   MONO_FONT,
+   PURPLE,
+   TEXT_MUTED,
+   TEXT_SECONDARY,
+} from "@/constants/theme";
 import type { Education } from "@/types";
 
 interface ExpandableExtrasProps {
    item: Education;
    marginLeft: number;
 }
-
-const EXPO_EASE = [0.16, 1, 0.3, 1] as const;
 
 const ExpandableExtras = ({ item, marginLeft }: ExpandableExtrasProps) => {
    const [isExpanded, setIsExpanded] = useState(false);
@@ -41,7 +46,7 @@ const ExpandableExtras = ({ item, marginLeft }: ExpandableExtrasProps) => {
                         padding: "3px 8px",
                         borderRadius: 6,
                         background: "rgba(168,85,247,0.08)",
-                        color: "#a855f7",
+                        color: PURPLE,
                         border: "1px solid rgba(168,85,247,0.15)",
                      }}
                   >
@@ -90,7 +95,7 @@ const ExpandableExtras = ({ item, marginLeft }: ExpandableExtrasProps) => {
                         initial={{ height: 0, opacity: 0 }}
                         animate={{ height: "auto", opacity: 1 }}
                         exit={{ height: 0, opacity: 0 }}
-                        transition={{ duration: 0.4, ease: EXPO_EASE }}
+                        transition={{ duration: 0.4, ease: EASING.cinematic }}
                         style={{ overflow: "hidden" }}
                      >
                         <ul
@@ -122,7 +127,7 @@ const ExpandableExtras = ({ item, marginLeft }: ExpandableExtrasProps) => {
                                  />
                                  <span
                                     style={{
-                                       color: "#a5a5c0",
+                                       color: TEXT_SECONDARY,
                                        fontSize: 12,
                                        lineHeight: 1.7,
                                     }}

--- a/src/pages/experience/CompanyHeader.tsx
+++ b/src/pages/experience/CompanyHeader.tsx
@@ -1,4 +1,5 @@
 import { Building2 } from "lucide-react";
+import { TEXT_PRIMARY, TEXT_SECONDARY, PURPLE } from "@/constants/theme";
 import type { ProfessionalExperience, PositionOfResponsibility } from "@/types";
 
 interface CompanyHeaderProps {
@@ -43,7 +44,7 @@ const CompanyHeader = ({
             style={{
                fontSize: isMobile ? 16 : 18,
                fontWeight: 700,
-               color: "#eeeef5",
+               color: TEXT_PRIMARY,
                lineHeight: 1.2,
             }}
          >
@@ -54,7 +55,7 @@ const CompanyHeader = ({
       {/* Title + Position */}
       <p
          style={{
-            color: "#a855f7",
+            color: PURPLE,
             fontWeight: 600,
             fontSize: isMobile ? 14 : 15,
             marginTop: 4,
@@ -81,7 +82,7 @@ const CompanyHeader = ({
       {item.summary && (
          <p
             style={{
-               color: "#a5a5c0",
+               color: TEXT_SECONDARY,
                fontSize: 12,
                lineHeight: 1.7,
                marginTop: 8,

--- a/src/pages/experience/Experience.tsx
+++ b/src/pages/experience/Experience.tsx
@@ -4,6 +4,7 @@ import { getExperience, getPositionsOfResponsibility } from "@data/dataLoader";
 import { staggerContainer, fadeInUp } from "@utils/animations";
 import useBreakpoint from "@hooks/useBreakpoint";
 import PageSection from "@components/layout/PageSection";
+import { CYAN, PURPLE, TEXT_PRIMARY, MAX_WIDTH_NARROW } from "@/constants/theme";
 import type { ProfessionalExperience } from "@/types";
 import TimelineCard from "./TimelineCard";
 import ExperienceModal from "./ExperienceModal";
@@ -25,7 +26,7 @@ const Experience = () => {
          id="experience"
          title="Experience"
          subtitle="Where I've worked"
-         maxWidth={960}
+         maxWidth={MAX_WIDTH_NARROW}
       >
          <LayoutGroup>
             <motion.div variants={staggerContainer}>
@@ -34,7 +35,7 @@ const Experience = () => {
                      key={item.id}
                      item={item}
                      index={index}
-                     accentColor="#06b6d4"
+                     accentColor={CYAN}
                      isMobile={isMobile}
                      onClick={() => setSelectedExp(item)}
                   />
@@ -49,7 +50,7 @@ const Experience = () => {
                   style={{
                      fontSize: 20,
                      fontWeight: 700,
-                     color: "#eeeef5",
+                     color: TEXT_PRIMARY,
                      marginTop: 48,
                      marginBottom: 32,
                      display: "flex",
@@ -62,8 +63,7 @@ const Experience = () => {
                         height: 28,
                         width: 4,
                         borderRadius: 9999,
-                        background:
-                           "linear-gradient(to bottom, #a855f7, rgba(168,85,247,0.3))",
+                        background: `linear-gradient(to bottom, ${PURPLE}, rgba(168,85,247,0.3))`,
                      }}
                   />
                   Positions of Responsibility
@@ -76,7 +76,7 @@ const Experience = () => {
                            key={item.id}
                            item={item}
                            index={index}
-                           accentColor="#a855f7"
+                           accentColor={PURPLE}
                            isMobile={isMobile}
                         />
                      ))}

--- a/src/pages/experience/ModalContent.tsx
+++ b/src/pages/experience/ModalContent.tsx
@@ -1,6 +1,6 @@
 import { motion } from "motion/react";
 import TechTag from "@components/ui/TechTag";
-import { TEXT_MUTED, CYAN } from "@/constants/theme";
+import { TEXT_MUTED, CYAN, EASING } from "@/constants/theme";
 import { waveCascadeContainer, waveCascadeItem } from "@utils/animations";
 import type { ProfessionalExperience } from "@/types";
 import ModalProjectCard from "./ModalProjectCard";
@@ -10,8 +10,6 @@ interface ModalContentProps {
    experience: ProfessionalExperience;
    isMobile: boolean;
 }
-
-const EXPO_EASE = [0.16, 1, 0.3, 1] as const;
 
 const ModalContent = ({ experience, isMobile }: ModalContentProps) => {
    const projects = experience.projects ?? [];
@@ -63,7 +61,7 @@ const ModalContent = ({ experience, isMobile }: ModalContentProps) => {
                transition={{
                   delay: skillsDelay,
                   duration: 0.4,
-                  ease: EXPO_EASE,
+                  ease: EASING.cinematic,
                }}
                style={{
                   marginTop: 20,

--- a/src/pages/experience/ModalContributions.tsx
+++ b/src/pages/experience/ModalContributions.tsx
@@ -5,6 +5,7 @@ import {
    TEXT_MUTED,
    AMBER,
    MONO_FONT,
+   EASING,
 } from "@/constants/theme";
 import type { InternalContribution } from "@/types";
 import { CONTRIB_ICON, CONTRIB_TYPE_COLOR } from "./experienceConstants";
@@ -15,8 +16,6 @@ interface ModalContributionsProps {
    baseDelay: number;
    variant: "contributions" | "achievements";
 }
-
-const EXPO_EASE = [0.16, 1, 0.3, 1] as const;
 
 const ModalContributions = ({
    title,
@@ -32,7 +31,7 @@ const ModalContributions = ({
       <motion.div
          initial={{ opacity: 0, y: 15 }}
          animate={{ opacity: 1, y: 0 }}
-         transition={{ delay: baseDelay, duration: 0.4, ease: EXPO_EASE }}
+         transition={{ delay: baseDelay, duration: 0.4, ease: EASING.cinematic }}
          style={{
             marginTop: 8,
             paddingTop: 16,

--- a/src/pages/experience/ModalHeader.tsx
+++ b/src/pages/experience/ModalHeader.tsx
@@ -27,7 +27,7 @@ const ModalHeader = ({ experience, onClose, isMobile }: ModalHeaderProps) => (
             size={isMobile ? 16 : 18}
             style={{ color: CYAN, flexShrink: 0 }}
          />
-         <h3
+         <h2
             id="experience-modal-title"
             style={{
                fontSize: isMobile ? 15 : 18,
@@ -41,7 +41,7 @@ const ModalHeader = ({ experience, onClose, isMobile }: ModalHeaderProps) => (
             }}
          >
             {experience.company}
-         </h3>
+         </h2>
       </div>
       <p
          style={{

--- a/src/pages/experience/ModalProjectCard.tsx
+++ b/src/pages/experience/ModalProjectCard.tsx
@@ -7,6 +7,7 @@ import {
    TEXT_MUTED,
    CYAN,
    MONO_FONT,
+   EASING,
 } from "@/constants/theme";
 import type { ExperienceProject } from "@/types";
 
@@ -15,8 +16,6 @@ interface ModalProjectCardProps {
    index: number;
 }
 
-const EXPO_EASE = [0.16, 1, 0.3, 1] as const;
-
 const ModalProjectCard = ({ project, index }: ModalProjectCardProps) => (
    <motion.div
       initial={{ opacity: 0, y: 25, scale: 0.98 }}
@@ -24,7 +23,7 @@ const ModalProjectCard = ({ project, index }: ModalProjectCardProps) => (
       transition={{
          delay: 0.2 + index * 0.12,
          duration: 0.4,
-         ease: EXPO_EASE,
+         ease: EASING.cinematic,
       }}
       style={{
          marginBottom: 20,

--- a/src/pages/experience/TimelineCard.tsx
+++ b/src/pages/experience/TimelineCard.tsx
@@ -1,4 +1,5 @@
 import type { ProfessionalExperience, PositionOfResponsibility } from "@/types";
+import { CYAN } from "@/constants/theme";
 import TimelineCardMobile from "./TimelineCardMobile";
 import TimelineCardDesktop from "./TimelineCardDesktop";
 
@@ -13,7 +14,7 @@ interface TimelineCardProps {
 const TimelineCard = ({
    item,
    index,
-   accentColor = "#06b6d4",
+   accentColor = CYAN,
    isMobile,
    onClick,
 }: TimelineCardProps) => {

--- a/src/pages/experience/TimelineCardDesktop.tsx
+++ b/src/pages/experience/TimelineCardDesktop.tsx
@@ -3,7 +3,7 @@ import { MapPin } from "lucide-react";
 import type { ProfessionalExperience, PositionOfResponsibility } from "@/types";
 import { slideInLeft, slideInRight } from "@utils/animations";
 import { splitDateRange, isPresent } from "@utils/dateRange";
-import { MONO_FONT, GREEN } from "@/constants/theme";
+import { MONO_FONT, GREEN, TEXT_MUTED } from "@/constants/theme";
 import TimelineCardContent from "./TimelineCardContent";
 import PresentIndicator from "./PresentIndicator";
 
@@ -72,7 +72,7 @@ const TimelineCardDesktop = ({
                      display: "block",
                      fontFamily: MONO_FONT,
                      fontSize: 11,
-                     color: "#6e6e90",
+                     color: TEXT_MUTED,
                      marginTop: 2,
                   }}
                >
@@ -82,7 +82,7 @@ const TimelineCardDesktop = ({
             {item.location && (
                <p
                   style={{
-                     color: "#6e6e90",
+                     color: TEXT_MUTED,
                      fontSize: 12,
                      display: "flex",
                      alignItems: "center",

--- a/src/pages/experience/TimelineCardMobile.tsx
+++ b/src/pages/experience/TimelineCardMobile.tsx
@@ -3,7 +3,7 @@ import { MapPin } from "lucide-react";
 import type { ProfessionalExperience, PositionOfResponsibility } from "@/types";
 import { staggerItem } from "@utils/animations";
 import { splitDateRange, isPresent } from "@utils/dateRange";
-import { MONO_FONT, GREEN } from "@/constants/theme";
+import { MONO_FONT, GREEN, TEXT_MUTED } from "@/constants/theme";
 import TimelineCardContent from "./TimelineCardContent";
 import PresentIndicator from "./PresentIndicator";
 
@@ -85,7 +85,7 @@ const TimelineCardMobile = ({
                {item.location && (
                   <span
                      style={{
-                        color: "#6e6e90",
+                        color: TEXT_MUTED,
                         fontSize: 11,
                         display: "flex",
                         alignItems: "center",

--- a/src/pages/experience/TimelineExpandedContent.tsx
+++ b/src/pages/experience/TimelineExpandedContent.tsx
@@ -1,6 +1,7 @@
 import { motion } from "motion/react";
 import { FolderGit2 } from "lucide-react";
 import type { ProfessionalExperience, PositionOfResponsibility } from "@/types";
+import { TEXT_MUTED } from "@/constants/theme";
 import { BulletList, SkillTags } from "./experienceHelpers";
 import { FADE_ENTRY } from "./experienceConstants";
 
@@ -51,7 +52,7 @@ const TimelineExpandedContent = ({
                   >
                      <p
                         style={{
-                           color: "#6e6e90",
+                           color: TEXT_MUTED,
                            fontSize: 12,
                            marginBottom: 8,
                            display: "flex",
@@ -61,7 +62,7 @@ const TimelineExpandedContent = ({
                      >
                         <FolderGit2
                            size={12}
-                           style={{ flexShrink: 0, color: "#6e6e90" }}
+                           style={{ flexShrink: 0, color: TEXT_MUTED }}
                         />
                         {project.name}
                      </p>
@@ -89,7 +90,7 @@ const TimelineExpandedContent = ({
                {...FADE_ENTRY}
                transition={{ duration: 0.4, ease: [0.4, 0, 0.2, 1] }}
                style={{
-                  color: "#6e6e90",
+                  color: TEXT_MUTED,
                   fontSize: 12,
                   marginTop: 16,
                   marginBottom: 8,
@@ -100,7 +101,7 @@ const TimelineExpandedContent = ({
             >
                <FolderGit2
                   size={12}
-                  style={{ flexShrink: 0, color: "#6e6e90" }}
+                  style={{ flexShrink: 0, color: TEXT_MUTED }}
                />
                {itemProject}
             </motion.p>

--- a/src/pages/experience/experienceHelpers.tsx
+++ b/src/pages/experience/experienceHelpers.tsx
@@ -1,4 +1,5 @@
 import TechTag from "@components/ui/TechTag";
+import { TEXT_SECONDARY } from "@/constants/theme";
 
 interface BulletListProps {
    items: string[];
@@ -23,11 +24,11 @@ export const BulletList = ({
          ...extraStyle,
       }}
    >
-      {items.map((desc) => (
+      {items.map((desc, i) => (
          <li
-            key={desc}
+            key={`${desc}-${i}`}
             style={{
-               color: "#a5a5c0",
+               color: TEXT_SECONDARY,
                fontSize,
                lineHeight: 1.7,
                display: "flex",
@@ -63,8 +64,8 @@ export const SkillTags = ({
    extraStyle,
 }: SkillTagsProps) => (
    <div style={{ display: "flex", flexWrap: "wrap", gap: 4, ...extraStyle }}>
-      {skills.map((skill) => (
-         <TechTag key={skill} label={skill} accent={accentColor} />
+      {skills.map((skill, i) => (
+         <TechTag key={`${skill}-${i}`} label={skill} accent={accentColor} />
       ))}
    </div>
 );

--- a/src/pages/github/CodingProfiles.tsx
+++ b/src/pages/github/CodingProfiles.tsx
@@ -93,7 +93,7 @@ const CodingProfiles = ({ githubUsername }: CodingProfilesProps) => {
                display: "grid",
                gridTemplateColumns: isMobile
                   ? "repeat(2, 1fr)"
-                  : `repeat(${entries.length + 1}, 1fr)`,
+                  : "repeat(auto-fit, minmax(160px, 1fr))",
                gap: 12,
             }}
          >

--- a/src/pages/github/GitHub.tsx
+++ b/src/pages/github/GitHub.tsx
@@ -3,6 +3,7 @@ import { GitHubCalendar } from "react-github-calendar";
 import type { Activity } from "react-github-calendar";
 import { getGitHubUsername } from "@data/dataLoader";
 import useBreakpoint from "@hooks/useBreakpoint";
+import { TEXT_MUTED, CYAN, MAX_WIDTH_WIDE } from "@/constants/theme";
 import CodingProfiles from "./CodingProfiles";
 import PageSection from "@components/layout/PageSection";
 import BrowserMockup from "@components/ui/BrowserMockup";
@@ -58,6 +59,35 @@ const CalendarSkeleton = () => (
    </div>
 );
 
+// -- Timeout fallback --
+const CalendarTimeout = ({ username }: { username: string }) => (
+   <div
+      role="status"
+      style={{
+         display: "flex",
+         flexDirection: "column",
+         alignItems: "center",
+         gap: 12,
+         padding: "32px 16px",
+         textAlign: "center",
+      }}
+   >
+      <p style={{ fontSize: 14, color: TEXT_MUTED, maxWidth: 360 }}>
+         GitHub is taking a while to respond. You can view the contributions
+         directly on GitHub.
+      </p>
+      <a
+         href={`https://github.com/${username}`}
+         target="_blank"
+         rel="noopener noreferrer"
+         className="btn-outline"
+         style={{ fontSize: 14, color: CYAN }}
+      >
+         Open GitHub profile
+      </a>
+   </div>
+);
+
 /** Stamp --col CSS variable on calendar rects for wave animation */
 const stampColumnIndices = (container: HTMLElement) => {
    const rects = container.querySelectorAll<SVGRectElement>(
@@ -89,6 +119,8 @@ const GitHub = () => {
    const githubUsername = getGitHubUsername();
    const [calendarState, dispatch] = useReducer(calendarReducer, "loading");
    const calendarRef = useRef<HTMLDivElement>(null);
+   const isLoaded = calendarState === "loaded";
+   const isTimedOut = calendarState === "timed-out";
    const isRevealed = calendarState !== "loading";
 
    const handleTransformData = useCallback(
@@ -101,12 +133,12 @@ const GitHub = () => {
    );
 
    useEffect(() => {
-      if (!isRevealed || !calendarRef.current) return;
+      if (!isLoaded || !calendarRef.current) return;
       const raf = requestAnimationFrame(() => {
          if (calendarRef.current) stampColumnIndices(calendarRef.current);
       });
       return () => cancelAnimationFrame(raf);
-   }, [isRevealed]);
+   }, [isLoaded]);
 
    useEffect(() => {
       const timeout = setTimeout(
@@ -122,7 +154,7 @@ const GitHub = () => {
          title="GitHub Activity"
          subtitle="My open source contributions"
       >
-         <div style={{ maxWidth: 1024, margin: "0 auto" }}>
+         <div style={{ maxWidth: MAX_WIDTH_WIDE, margin: "0 auto" }}>
             {/* 3D Browser Mockup */}
             <div style={{ textAlign: "center" }}>
                <BrowserMockup
@@ -131,13 +163,16 @@ const GitHub = () => {
                >
                   <div
                      ref={calendarRef}
-                     className={isRevealed ? "calendar-reveal" : ""}
+                     className={isLoaded ? "calendar-reveal" : ""}
                      style={{ overflowX: "auto" }}
                   >
                      {!isRevealed && <CalendarSkeleton />}
+                     {isTimedOut && (
+                        <CalendarTimeout username={githubUsername} />
+                     )}
                      <div
                         style={
-                           isRevealed
+                           isLoaded
                               ? {}
                               : {
                                    position: "absolute",

--- a/src/pages/portfolio/ContribCard.tsx
+++ b/src/pages/portfolio/ContribCard.tsx
@@ -1,6 +1,12 @@
 import { GitMerge, CircleDot, GitPullRequestClosed } from "lucide-react";
 import type { OpenSourceContribution } from "@/types";
-import { MONO_FONT, PURPLE, GREEN, ORANGE } from "@/constants/theme";
+import {
+   MONO_FONT,
+   PURPLE,
+   GREEN,
+   ORANGE,
+   TEXT_SECONDARY,
+} from "@/constants/theme";
 
 interface ContribCardProps {
    contrib: OpenSourceContribution;
@@ -87,7 +93,7 @@ const ContribCard = ({ contrib }: ContribCardProps) => {
             <p
                style={{
                   fontSize: 12,
-                  color: "#a5a5c0",
+                  color: TEXT_SECONDARY,
                   lineHeight: 1.5,
                   marginTop: 2,
                   overflow: "hidden",

--- a/src/pages/portfolio/DiscussionCard.tsx
+++ b/src/pages/portfolio/DiscussionCard.tsx
@@ -1,14 +1,14 @@
 import { BadgeCheck, MessageCircle } from "lucide-react";
 import type { CommunityDiscussion } from "@/types";
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, CYAN, PURPLE, TEXT_SECONDARY } from "@/constants/theme";
 
 interface DiscussionCardProps {
    discussion: CommunityDiscussion;
 }
 
 const STATUS_CONFIG = {
-   accepted: { color: "#06b6d4", Icon: BadgeCheck, label: "Accepted" },
-   helpful: { color: "#a855f7", Icon: MessageCircle, label: "Helpful" },
+   accepted: { color: CYAN, Icon: BadgeCheck, label: "Accepted" },
+   helpful: { color: PURPLE, Icon: MessageCircle, label: "Helpful" },
 } as const;
 
 const DiscussionCard = ({ discussion }: DiscussionCardProps) => {
@@ -88,7 +88,7 @@ const DiscussionCard = ({ discussion }: DiscussionCardProps) => {
             <p
                style={{
                   fontSize: 12,
-                  color: "#a5a5c0",
+                  color: TEXT_SECONDARY,
                   lineHeight: 1.5,
                   marginTop: 2,
                   overflow: "hidden",

--- a/src/pages/portfolio/OpenSourceBanner.tsx
+++ b/src/pages/portfolio/OpenSourceBanner.tsx
@@ -33,7 +33,7 @@ const OpenSourceBanner = () => {
          style={{ marginTop: 48 }}
          initial={{ opacity: 0, y: 30 }}
          whileInView={{ opacity: 1, y: 0 }}
-         viewport={{ margin: "0px 0px -100px 0px" }}
+         viewport={{ once: true, margin: "0px 0px -100px 0px" }}
          transition={{ duration: 0.7, ease: [0.4, 0, 0.2, 1] }}
       >
          <div

--- a/src/pages/portfolio/Portfolio.tsx
+++ b/src/pages/portfolio/Portfolio.tsx
@@ -8,7 +8,7 @@ import {
 } from "@data/dataLoader";
 import { fadeInUp } from "@utils/animations";
 import useBreakpoint from "@hooks/useBreakpoint";
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, TEXT_SECONDARY, MAX_WIDTH } from "@/constants/theme";
 import PageSection from "@components/layout/PageSection";
 import { FILTERS, parseDate } from "./portfolioConstants";
 import type { ProjectWithCategory } from "./portfolioConstants";
@@ -104,10 +104,7 @@ const Portfolio = () => {
 
    return (
       <PageSection id="projects" title="Projects" subtitle="Things I've built">
-         <div
-            className="max-w-6xl mx-auto"
-            style={{ maxWidth: 1152, margin: "0 auto" }}
-         >
+         <div style={{ maxWidth: MAX_WIDTH, margin: "0 auto" }}>
             {/* Filter buttons */}
             <motion.div
                style={{
@@ -139,7 +136,7 @@ const Portfolio = () => {
                                    cursor: "pointer",
                                    border:
                                       "1px solid rgba(255, 255, 255, 0.06)",
-                                   color: "#a5a5c0",
+                                   color: TEXT_SECONDARY,
                                    background: "rgba(255, 255, 255, 0.03)",
                                    backdropFilter: "blur(8px)",
                                    display: "inline-flex",

--- a/src/pages/portfolio/ProjectCard.tsx
+++ b/src/pages/portfolio/ProjectCard.tsx
@@ -2,7 +2,7 @@ import { motion } from "motion/react";
 import { ExternalLink } from "lucide-react";
 import { FaGithub } from "react-icons/fa6";
 import { scaleRotateIn } from "@utils/animations";
-import { MONO_FONT } from "@/constants/theme";
+import { MONO_FONT, TEXT_SECONDARY } from "@/constants/theme";
 import {
    getCategoryColors,
    isValidUrl,
@@ -104,7 +104,7 @@ const ProjectCard = ({ data, index = 0, onOpen }: ProjectCardProps) => {
             {/* Description */}
             <p
                style={{
-                  color: "#a5a5c0",
+                  color: TEXT_SECONDARY,
                   fontSize: 12,
                   lineHeight: 1.7,
                   marginBottom: 16,

--- a/src/pages/portfolio/ProjectLink.tsx
+++ b/src/pages/portfolio/ProjectLink.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType } from "react";
+import { CYAN, TEXT_SECONDARY } from "@/constants/theme";
 
 interface ProjectLinkProps {
    href: string;
@@ -13,7 +14,7 @@ const ProjectLink = ({
    label,
    ariaLabel,
    icon: Icon,
-   accentColor = "#06b6d4",
+   accentColor = CYAN,
 }: ProjectLinkProps) => (
    <a
       href={href}
@@ -28,19 +29,19 @@ const ProjectLink = ({
          borderRadius: 10,
          fontSize: 12,
          fontWeight: 500,
-         color: "#a5a5c0",
+         color: TEXT_SECONDARY,
          border: "1px solid rgba(255, 255, 255, 0.06)",
          background: "rgba(255, 255, 255, 0.03)",
          backdropFilter: "blur(8px)",
          textDecoration: "none",
-         transition: "all 0.2s",
+         transition: "color 0.2s ease, border-color 0.2s ease",
       }}
       onMouseEnter={(e: React.MouseEvent<HTMLAnchorElement>) => {
          e.currentTarget.style.color = accentColor;
          e.currentTarget.style.borderColor = `${accentColor}4D`;
       }}
       onMouseLeave={(e: React.MouseEvent<HTMLAnchorElement>) => {
-         e.currentTarget.style.color = "#a5a5c0";
+         e.currentTarget.style.color = TEXT_SECONDARY;
          e.currentTarget.style.borderColor = "rgba(255, 255, 255, 0.06)";
       }}
       aria-label={ariaLabel}

--- a/src/pages/portfolio/ProjectModalBody.tsx
+++ b/src/pages/portfolio/ProjectModalBody.tsx
@@ -8,6 +8,7 @@ import {
    TEXT_SECONDARY,
    TEXT_MUTED,
    MONO_FONT,
+   EASING,
 } from "@/constants/theme";
 import {
    isValidUrl,
@@ -21,13 +22,11 @@ interface ProjectModalBodyProps {
    isMobile: boolean;
 }
 
-const EXPO_EASE = [0.16, 1, 0.3, 1] as const;
-
 /** Shared fade-in-up transition used by every section in the modal body. */
 const fadeInUpProps = (delay: number) => ({
    initial: { opacity: 0, y: 10 },
    animate: { opacity: 1, y: 0 },
-   transition: { delay, duration: 0.4, ease: EXPO_EASE },
+   transition: { delay, duration: 0.4, ease: EASING.cinematic },
 });
 
 const sectionLabelStyle: React.CSSProperties = {

--- a/src/pages/portfolio/ProjectModalHeader.tsx
+++ b/src/pages/portfolio/ProjectModalHeader.tsx
@@ -37,7 +37,7 @@ const ProjectModalHeader = ({
                size={isMobile ? 16 : 18}
                style={{ color: colors.accent, flexShrink: 0 }}
             />
-            <h3
+            <h2
                id="project-modal-title"
                style={{
                   fontSize: isMobile ? 15 : 18,
@@ -51,7 +51,7 @@ const ProjectModalHeader = ({
                }}
             >
                {project.title}
-            </h3>
+            </h2>
          </div>
 
          <div

--- a/src/pages/portfolio/portfolioConstants.ts
+++ b/src/pages/portfolio/portfolioConstants.ts
@@ -26,7 +26,9 @@ export const MONTHS: Record<string, number> = {
 
 export const parseDate = (dateStr: string): Date => {
    const [month, year] = dateStr.split(" ");
-   return new Date(Number(year), MONTHS[month] || 0);
+   const y = Number(year);
+   // ?? (not ||) so a valid "January" (index 0) isn't treated as missing.
+   return new Date(Number.isFinite(y) ? y : 0, MONTHS[month] ?? 0);
 };
 
 export interface CategoryColors {

--- a/src/pages/services/ServiceCard.tsx
+++ b/src/pages/services/ServiceCard.tsx
@@ -3,6 +3,7 @@ import { Code } from "lucide-react";
 import type { Variants } from "motion/react";
 import type { Service } from "@/types";
 import useBreakpoint from "@hooks/useBreakpoint";
+import { TEXT_PRIMARY, TEXT_SECONDARY } from "@/constants/theme";
 import GlassCard from "@components/ui/GlassCard";
 import { iconMap, ACCENT_COLORS } from "./servicesConstants";
 import ServiceAnimation from "./ServiceAnimation";
@@ -83,7 +84,7 @@ const ServiceCard = ({ service, index }: ServiceCardProps) => {
                   style={{
                      fontSize: 14,
                      fontWeight: 700,
-                     color: "#eeeef5",
+                     color: TEXT_PRIMARY,
                      marginBottom: 8,
                      display: "flex",
                      alignItems: "center",
@@ -115,7 +116,7 @@ const ServiceCard = ({ service, index }: ServiceCardProps) => {
                            display: "flex",
                            alignItems: "flex-start",
                            gap: 8,
-                           color: "#a5a5c0",
+                           color: TEXT_SECONDARY,
                            fontSize: 12,
                            lineHeight: 1.5,
                         }}

--- a/src/pages/services/Services.tsx
+++ b/src/pages/services/Services.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { motion } from "motion/react";
 import { getServices } from "@data/dataLoader";
 import { staggerContainer } from "@utils/animations";
+import { MAX_WIDTH } from "@/constants/theme";
 import useBreakpoint from "@hooks/useBreakpoint";
 import PageSection from "@components/layout/PageSection";
 import ServiceCard from "./ServiceCard";
@@ -14,7 +15,7 @@ const Services = () => {
       <PageSection id="services" title="Services" subtitle="What I offer">
          <motion.div
             style={{
-               maxWidth: 1152,
+               maxWidth: MAX_WIDTH,
                margin: "0 auto",
                display: "grid",
                gap: 20,

--- a/src/pages/skill/SecondarySkills.tsx
+++ b/src/pages/skill/SecondarySkills.tsx
@@ -5,6 +5,7 @@ import {
    waveCascadeContainer,
    waveCascadeItem,
 } from "@utils/animations";
+import { TEXT_PRIMARY, TEXT_SECONDARY, PURPLE } from "@/constants/theme";
 
 interface CategoryEntry {
    key: string;
@@ -41,7 +42,7 @@ const SecondarySkills = ({ categories }: SecondarySkillsProps) => {
             style={{
                fontSize: 20,
                fontWeight: 600,
-               color: "#eeeef5",
+               color: TEXT_PRIMARY,
                textAlign: "center",
             }}
          >
@@ -53,7 +54,7 @@ const SecondarySkills = ({ categories }: SecondarySkillsProps) => {
                   style={{
                      fontSize: 16,
                      fontWeight: 500,
-                     color: "#a5a5c0",
+                     color: TEXT_SECONDARY,
                      marginBottom: 12,
                      display: "flex",
                      alignItems: "center",
@@ -65,8 +66,7 @@ const SecondarySkills = ({ categories }: SecondarySkillsProps) => {
                         height: 20,
                         width: 3,
                         borderRadius: 9999,
-                        background:
-                           "linear-gradient(to bottom, #a855f7, rgba(168,85,247,0.3))",
+                        background: `linear-gradient(to bottom, ${PURPLE}, rgb(var(--ch-purple) / 0.3))`,
                      }}
                   />
                   {label}
@@ -76,7 +76,7 @@ const SecondarySkills = ({ categories }: SecondarySkillsProps) => {
                   variants={waveCascadeContainer}
                   initial="hidden"
                   whileInView="visible"
-                  viewport={{ margin: "0px 0px -100px 0px" }}
+                  viewport={{ once: true, margin: "0px 0px -100px 0px" }}
                >
                   {items.map((skill) => (
                      <motion.span

--- a/src/pages/skill/Skill.tsx
+++ b/src/pages/skill/Skill.tsx
@@ -3,7 +3,7 @@ import { motion } from "motion/react";
 import { getSkills } from "@data/dataLoader";
 import type { SkillsData } from "@/types";
 import { staggerContainer, staggerItem } from "@utils/animations";
-import { CYAN } from "@/constants/theme";
+import { CYAN, TEXT_PRIMARY, MAX_WIDTH } from "@/constants/theme";
 import PageSection from "@components/layout/PageSection";
 import SkillTagGroup from "./SkillTagGroup";
 import SecondarySkills from "./SecondarySkills";
@@ -56,7 +56,7 @@ const Skill = () => {
          title="Skills & Technologies"
          subtitle="What I work with"
       >
-         <div style={{ maxWidth: 1152, margin: "0 auto" }}>
+         <div style={{ maxWidth: MAX_WIDTH, margin: "0 auto" }}>
             <motion.div
                style={{ display: "flex", flexDirection: "column", gap: 48 }}
                variants={staggerContainer}
@@ -67,7 +67,7 @@ const Skill = () => {
                         style={{
                            fontSize: 20,
                            fontWeight: 600,
-                           color: "#eeeef5",
+                           color: TEXT_PRIMARY,
                            marginBottom: 16,
                            display: "flex",
                            alignItems: "center",

--- a/src/pages/skill/SkillTagGroup.tsx
+++ b/src/pages/skill/SkillTagGroup.tsx
@@ -7,12 +7,11 @@ interface SkillTagGroupProps {
 
 const SkillTagGroup = ({ items }: SkillTagGroupProps) => (
    <motion.div
-      className="flex flex-wrap gap-2.5"
       style={{ display: "flex", flexWrap: "wrap", gap: 8 }}
       variants={waveCascadeContainer}
       initial="hidden"
       whileInView="visible"
-      viewport={{ margin: "0px 0px -100px 0px" }}
+      viewport={{ once: true, margin: "0px 0px -100px 0px" }}
    >
       {items.map((skill) => (
          <motion.span

--- a/src/utils/credlyThumb.ts
+++ b/src/utils/credlyThumb.ts
@@ -6,7 +6,15 @@
 const CREDLY_HOST = "images.credly.com";
 
 export const credlyThumb = (url: string, px = 220): string => {
-   if (!url.includes(CREDLY_HOST)) return url;
+   let host: string;
+   try {
+      // Parse and check the exact host -- a substring test would match hostile
+      // URLs like https://images.credly.com.evil.com/ or https://e.com/?images.credly.com.
+      host = new URL(url).hostname;
+   } catch {
+      return url;
+   }
+   if (host !== CREDLY_HOST) return url;
    // Already sized? leave it.
    if (url.includes("/size/")) return url;
    // Insert /size/NxN right before the /images/ segment.

--- a/src/utils/credlyThumb.ts
+++ b/src/utils/credlyThumb.ts
@@ -1,0 +1,14 @@
+// Credly badge images are stored at 600-1600px but rendered at 70-96px. Credly's
+// CDN serves a resized variant via a /size/NxN/ path segment, so we request a
+// retina-appropriate thumbnail instead of shipping the full-resolution badge.
+// Applied at render time (not in the synced achievements.json) so it survives the
+// weekly Credly sync. Non-Credly URLs pass through untouched.
+const CREDLY_HOST = "images.credly.com";
+
+export const credlyThumb = (url: string, px = 220): string => {
+   if (!url.includes(CREDLY_HOST)) return url;
+   // Already sized? leave it.
+   if (url.includes("/size/")) return url;
+   // Insert /size/NxN right before the /images/ segment.
+   return url.replace("/images/", `/size/${px}x${px}/images/`);
+};


### PR DESCRIPTION
## What

A refinement pass across the whole site: accessibility, scroll/load performance, motion polish, design-token consistency, and several real bug fixes. No new dependencies, no content or UI removed, motion kept visible.

The work was driven by a parallel multi-dimension audit + adversarial verification, then a DevTools performance trace to find the actual scroll-lag root cause (not guesses).

## Why the site lagged on fast scroll

A trace under CPU throttle showed **50 simultaneous `backdrop-filter` blur layers** and a long forced-reflow window during scroll. `backdrop-filter` only caches while its backdrop is static, but the backdrop here (aurora blobs + 3D canvas) animates every frame -- so blurs recomputed continuously. The worst offenders were **5 full-viewport-width `.section-darker` bands** re-blurring the moving background.

## Changes

**Performance (scroll)**
- Replaced the 5 full-width `.section-darker` backdrop-blur bands with gradient overlays -- the dominant fast-scroll repaint. Verified gone in the built CSS.
- AuroraBlobs animate `transform` (GPU) instead of `left/top` (per-frame layout).
- 3D scene pauses during active scroll (resumes at rest) and is gated to desktop.
- NavBar no longer transitions its blur radius; glass blur 12->10px.
- Removed the cursor-following conic-gradient card border (heaviest per-frame paint, also calmer).
- Lenis tuned to lerp-based smoothing so fast flicks stay responsive; all in-page scroll routed through Lenis; `overscroll-behavior` added.

**Performance (load)**
- Credly badges request `/size/220x220` thumbnails: ~43KB -> 25KB each across 20 badges, sharper on retina. Render-time helper, survives the weekly sync.

**Accessibility (WCAG 2.2)**
- Skip-to-content link + `main` landmark; nav `aria-label`/`aria-current`/`aria-expanded`/`aria-controls`.
- MobileMenu is now a real dialog: focus trap, Escape, body scroll-lock, focus return.
- Contact form: `aria-invalid` + inline `role="alert"` error; success announced to screen readers.
- Modal titles h3->h2; focus-trap edge fix; bare-key shortcut guard.
- `TEXT_MUTED` bumped to clear AA contrast on the dark glass.

**Bug fixes**
- AnimatedCounter: cancel rAF on unmount, render decimals (CGPA), drop redundant ref.
- ParticleField: regenerate positions on `count` change (buffer desync).
- InteractiveConstellation: cancel rAF before restart (visibilitychange loop stacking).
- Contact form: preserve sender name on the success screen; surface non-200 send responses.
- `parseDate` month/year guards; stable list keys.

**Design system**
- Routed raw hex/rgba/easing literals through `theme.ts` tokens + `--ch-*` channels across the tree; wired `MAX_WIDTH*`/type tokens into sections; removed dead `BLUE` token.

## Testing

- `pnpm type-check`, `pnpm lint` (0 warnings), `pnpm test` (4/4), `pnpm build` -- all green locally.
- Verified in-browser (Chrome DevTools): 0 console errors, MobileMenu dialog behavior (focus trap + Escape + scroll-lock + focus return), skip link, resized badge URLs, and that `.section-darker` ships as a gradient with no backdrop-filter.

**Caveat:** a clean before/after FPS number wasn't reproducible on the dev box (identical runs swung 24->51 fps; scripted scroll fights Lenis). What's deterministically proven is that the measured root causes are removed from the shipped build. Best validated with a real wheel-scroll.

## Notes

- Pre-existing Dependabot alerts on `main` are unrelated to this PR (no deps added/changed).
