### PR TITLE
fix: strip regex delimiters so email validation works

### DIFF
--- a/data/contact.json
+++ b/data/contact.json
@@ -45,6 +45,6 @@
       "service_id": "service_lyt547p",
       "template_id": "template_yz438w6",
       "public_key": "PAcL61ygLI8WYG16R",
-      "validation_pattern": "/^[\\w.%+-]+@[\\w.-]+\\.[a-zA-Z]{2,}$/"
+      "validation_pattern": "^[\\w.%+-]+@[\\w.-]+\\.[a-zA-Z]{2,}$"
    }
 }


### PR DESCRIPTION
## What

Removes the leading and trailing `/` from `email_config.validation_pattern` in `data/contact.json`. The pattern itself is unchanged.

## Why

`useContactForm.ts` feeds the string straight into `new RegExp(emailConfig.validation_pattern)`. Unlike a regex literal, `new RegExp("/.../")` treats the surrounding slashes as literal characters, so the compiled pattern required emails to literally start with `/` and end with `/`. Result: every valid email was rejected on the contact form.

## Change

`"/^[\w.%+-]+@[\w.-]+\.[a-zA-Z]{2,}$/"` → `"^[\w.%+-]+@[\w.-]+\.[a-zA-Z]{2,}$"`

One line, one file. No behavior change beyond making validation actually work.