### PR TITLE
fix: sync portfolio data with live repos and canonical FACTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ CLAUDE.md
 
 # Vite
 vite.config.js.timestamp-*
+
+# Claude session memory (local only)
+.remember/

--- a/data/achievements.json
+++ b/data/achievements.json
@@ -2,7 +2,7 @@
   "certifications": [
     {
       "id": 1,
-      "name": "AWS Certified Developer – Associate",
+      "name": "AWS Certified Developer - Associate",
       "type": "Industry Certification",
       "issuer": "Amazon Web Services Training and Certification",
       "issueDate": "2026-01-31",
@@ -26,7 +26,7 @@
     },
     {
       "id": 3,
-      "name": "AWS Certified Machine Learning Engineer – Associate",
+      "name": "AWS Certified Machine Learning Engineer - Associate",
       "type": "Industry Certification",
       "issuer": "Amazon Web Services Training and Certification",
       "issueDate": "2025-06-28",
@@ -50,7 +50,7 @@
     },
     {
       "id": 5,
-      "name": "AWS Certified Solutions Architect – Associate",
+      "name": "AWS Certified Solutions Architect - Associate",
       "type": "Industry Certification",
       "issuer": "Amazon Web Services Training and Certification",
       "issueDate": "2024-07-07",
@@ -69,7 +69,7 @@
       "badgeId": "bf8ffb47-284c-4c45-adb8-3df4f807e404",
       "badgeUrl": "https://www.credly.com/badges/bf8ffb47-284c-4c45-adb8-3df4f807e404",
       "level": "Foundational",
-      "expiryDate": "2029-01-31",
+      "expiryDate": "2027-05-02",
       "imageUrl": "https://images.credly.com/images/00634f82-b07f-4bbd-a6bb-53de397fc3a6/image.png"
     }
   ],
@@ -260,14 +260,14 @@
       "id": 5,
       "title": "Rank 1289 - Google Kick Start '22, Round E",
       "organizer": "Google",
-      "date": "August 2022",
+      "date": "September 2022",
       "type": "Competition"
     },
     {
       "id": 6,
       "title": "Rank 1699 - Google Kick Start '22, Round B",
       "organizer": "Google",
-      "date": "April 2022",
+      "date": "May 2022",
       "type": "Competition"
     },
     {

--- a/data/education.json
+++ b/data/education.json
@@ -35,7 +35,7 @@
       "department": "Department of Computer Science & Engineering",
       "alsoKnownAs": "University of Indore",
       "location": "Indore, Madhya Pradesh, India",
-      "cgpa": "",
+      "cgpa": "7.34",
       "percentage": "",
       "display_text": "Devi Ahilya Vishwavidyalaya (DAVV) - Indore, MP",
       "skills": [

--- a/data/experience.json
+++ b/data/experience.json
@@ -3,7 +3,7 @@
       {
          "id": 1,
          "date": "August 2024 - Present",
-         "title": "Professional Services (Cloud Consultant) - DevOps/MLOps",
+         "title": "Cloud Consultant - Professional Services (DevOps/MLOps)",
          "position": "Full-time",
          "company": "Amazon Web Services",
          "location": "Hyderabad, India",
@@ -13,11 +13,11 @@
                "name": "Lead DevOps Consultant - RWS (Ongoing)",
                "date": "Feb 2026 - Present",
                "description": {
-                  "1": "Leading greenfield AWS migration as the sole DevOps consultant - designing AWS Organizations OU structure, SCPs, tag policies, and deploying Terraform infrastructure with GitHub Actions CI/CD across multi-account environments.",
-                  "2": "Implemented governance and infrastructure security controls - preventative SCPs, tag compliance guardrails, Config rules, and Security Hub standards across the org - enforcing least-privilege access and regulatory alignment from day one.",
+                  "1": "Leading greenfield AWS migration as the sole DevOps consultant - onboarding 50+ application workloads into 135+ AWS accounts, designing AWS Organizations OU structure, SCPs, tag policies, and Terraform + GitHub Actions CI/CD, cutting infrastructure setup time ~90% (3+ days per account to under 4 hours) versus manual provisioning.",
+                  "2": "Implemented governance and infrastructure security controls - preventative SCPs, tag compliance guardrails, Config rules, and Security Hub standards across the org - enforcing least-privilege access and CCMv4-aligned regulatory posture from day one.",
                   "3": "Architecting the multi-account networking foundation - Transit Gateway hub-and-spoke, centralized VPC design, hybrid connectivity (VPN/Direct Connect), DNS resolution, and egress control via centralized inspection.",
-                  "4": "Driving architecture decisions and defining migration roadmap for 50+ application workloads. Delivering recommendations on cost optimization, HA, and DR to customer stakeholders.",
-                  "5": "Leveraging Kiro for AI-driven requirement analysis, architecture documentation, and implementation specs - significantly accelerating delivery velocity."
+                  "4": "Driving architecture decisions and defining migration roadmap for 50+ application workloads into 135+ AWS accounts. Delivering recommendations on cost optimization, HA, and DR to customer stakeholders.",
+                  "5": "Used Kiro for AI-driven requirement analysis, architecture documentation, and implementation specs."
                },
                "skills": [
                   "AWS",
@@ -43,7 +43,7 @@
                "date": "Aug 2025 - Dec 2025",
                "description": {
                   "1": "Refactored and created critical Terraform infrastructure code to enhance security and scalability, solving complex legacy modernization challenges in financial services.",
-                  "2": "Leveraged Amazon Q AI capabilities to accelerate development workflows, code analysis, and migration assessments, transforming infrastructure patterns to align with cloud-native principles.",
+                  "2": "Used Amazon Q to accelerate code analysis and migration assessments, transforming infrastructure patterns to align with cloud-native principles.",
                   "3": "Partnered with client engineering teams on secure infrastructure practices and knowledge transfer."
                },
                "skills": [
@@ -81,7 +81,7 @@
                "date": "Oct 2024 - Aug 2025",
                "description": {
                   "1": "Built Terraform module library covering 38+ AWS services with automated testing (tftest, PyTest), adopted across the client's cloud platform by application teams.",
-                  "2": "Architected 1000+ preventative security controls aligned with CCMv4.0 compliance requirements, designing self-service capabilities with governance guardrails.",
+                  "2": "Architected 1000+ preventative security controls (AWS Config rules and Security Hub standards) aligned with CCMv4.0 compliance requirements, designing self-service capabilities with governance guardrails.",
                   "3": "Delivered POCs showcasing use-cases of various AWS services through Terraform, and implemented evidence and federated architecture patterns.",
                   "4": "Collaborated across Landing Zone, Compliance, Security, and Migrations workstreams. Achieved 10/10 CSAT score and 3 consecutive 5/5 Pulse ratings from customer."
                },
@@ -129,7 +129,7 @@
                "year": "2025"
             },
             {
-               "title": "4x TFC Ambassador: AI/ML, NGDE, CloudOps DevOps Agent, Agentic AI",
+               "title": "5x TFC Ambassador: AI/ML, NGDE (Graduated), CloudOps (AWS DevOps Agent), Agentic AI, Serverless",
                "type": "program",
                "year": "2025-2026"
             },

--- a/data/personal.json
+++ b/data/personal.json
@@ -1,6 +1,6 @@
 {
    "name": "Sagar Gupta",
-   "title": "Professional Services (Cloud Consultant) - DevOps/MLOps at AWS",
+   "title": "Cloud Consultant -- Professional Services (DevOps/MLOps) at AWS",
    "location": "Hyderabad, India",
    "contact": {
       "email": "sg85207@gmail.com",
@@ -21,15 +21,15 @@
       "current_role": "💼 Cloud & DevOps/MLOps Engineer at AWS Professional Services, delivering DevOps engagements for leading financial institutions like State Street and DTCC. Leading a greenfield AWS migration for 50+ application workloads at RWS.",
       "specialization": "🚀 Built production MLOps pipelines on SageMaker, published architecture patterns on AWS Prescriptive Guidance, and contributed to major open source projects including Apache Airflow, Terraform Provider AWS, and Feast.",
       "education": "🎓 Completed MCA from National Institute of Technology, Warangal (CGPA: 8.38, NIMCET AIR 208). 6x certified across AWS and Terraform.",
-      "competitive_programming": "🏆 LeetCode Knight (2007 peak rating), 2000+ problems solved across platforms, 140+ contests. Google Kick Start '22 Top 5%."
+      "competitive_programming": "🏆 LeetCode Knight (2007 peak rating), 1600+ problems across LeetCode and GeeksforGeeks, 100+ contests. Google Kick Start '22 Top 5%."
    },
    "statistics": {
-      "coding_questions": "2000+",
+      "coding_questions": "1600+",
       "leetcode_rating": "2007",
       "projects": "25+",
-      "contests": "140+",
+      "contests": "100+",
       "industry_certifications": "6",
-      "open_source_prs": "13+"
+      "open_source_prs": "6 merged + 1 open"
    },
    "languages": [
       { "name": "English", "level": "Professional Working" },

--- a/data/projects.json
+++ b/data/projects.json
@@ -26,8 +26,8 @@
       {
          "id": 15,
          "title": "Ledger Sync",
-         "description": "A self-hosted personal finance dashboard (v2.9.0) with an AI chatbot that uses 15 read-only tool calls to answer questions about your spending, trends, tax, and goals. Upload Excel/CSV bank statements, get SHA-256 deduplication, FIRE planning (Lean/Barista/Standard/Fat), India FY tax estimation, Sankey cash flow, and a Financial Health Score across 8 metrics.",
-         "date": "January 2026",
+         "description": "A self-hosted personal finance dashboard (v2.19.0) with an AI chatbot that uses 15 read-only tool calls to answer questions about your spending, trends, tax, and goals. Upload Excel/CSV bank statements, get SHA-256 deduplication, 50/30/20 budgeting, bill calendar, GST analysis, subscription tracking, year-in-review, FIRE planning (Lean/Barista/Standard/Fat), India FY tax estimation, Sankey cash flow, and a Financial Health Score across 8 metrics.",
+         "date": "July 2026",
          "tools_tech": [
             "TypeScript",
             "React 19",
@@ -40,7 +40,7 @@
          ],
          "features": [
             "AI finance chatbot with 15 tool calls (App mode or BYOK), multi-provider LLM support",
-            "Demo mode at /demo with ~500 sample transactions, all 23 pages render",
+            "50/30/20 Budget Rule page, bill calendar, GST analysis, subscription tracker, year-in-review",
             "FIRE calculator (Lean/Barista/Standard/Fat), Coast FIRE, retirement corpus, India FY tax estimator",
             "Financial Health Score, Sankey cash flow, anomaly detection, recurring transaction detection"
          ],
@@ -50,7 +50,7 @@
       {
          "id": 2,
          "title": "LeetCode Rating Predictor",
-         "description": "Full-stack LeetCode contest rating predictor using a Dense neural network trained on 121K+ contest records, featuring a FastAPI backend with LeetCode GraphQL integration and a React glassmorphism frontend.",
+         "description": "Full-stack LeetCode contest rating predictor using a Dense neural network trained on 244K+ contest records, featuring a FastAPI backend with LeetCode GraphQL integration and a React glassmorphism frontend.",
          "date": "December 2023",
          "tools_tech": [
             "Python",
@@ -61,7 +61,7 @@
             "GraphQL"
          ],
          "features": [
-            "Dense neural network trained on 121K+ contest records",
+            "Dense neural network trained on 244K+ contest records",
             "Automated data pipeline via LeetCode GraphQL API",
             "Glassmorphism React frontend with live contest selection",
             "34 backend tests + 11 frontend tests, Docker + Render deploy"
@@ -159,7 +159,7 @@
       {
          "id": 39,
          "title": "Code Arena",
-         "description": "A real-time competitive coding platform where 2-5 friends race to solve LeetCode problems with built-in C++ and Python execution via sandboxed Piston containers. Features Blind Race and Live Status Board modes with a server-authoritative WebSocket timer and LeetCode-style Monaco editor.",
+         "description": "A real-time competitive coding platform where 2-5 friends race to solve LeetCode problems with built-in C++ and Python execution via sandboxed Piston containers. Features Blind Race and Live Status Board modes with a server-authoritative WebSocket timer and LeetCode-style Monaco editor. Live demo is UI-only (backend offline).",
          "date": "April 2026",
          "tools_tech": [
             "React 19",
@@ -178,7 +178,7 @@
             "Server-authoritative WebSocket timer, Monaco editor with language toggle and test cases"
          ],
          "github": "https://github.com/Sagargupta16/code-arena",
-         "live": "",
+         "live": "https://sagargupta.online/code-arena/",
          "team": "Sagar & Pranshu",
          "contributors": [
             "Sagargupta16",
@@ -328,22 +328,21 @@
       {
          "id": 40,
          "title": "Instagram Autopilot",
-         "description": "Fully automated Instagram content creation and posting powered by AWS Bedrock AI and Composio v3. Daily cron generates topics, captions, premium 1024x1024 AI images via Nova Canvas (neon/cinematic styling), and optional 6-second Reels via Nova Reel - then auto-publishes via GitHub Actions.",
-         "date": "March 2026",
+         "description": "Fully automated Instagram content creation and posting powered by AWS Bedrock AI and Composio v3, publishing live daily. Cron generates topics, captions, and premium AI image carousels via Stability Image Ultra, with dedup history, content-filter resilience (skips filtered slides, publishes if 2+ remain), and Instagram location tags via Meta Places - all through GitHub Actions.",
+         "date": "July 2026",
          "tools_tech": [
             "Python",
             "AWS Bedrock",
-            "Nova Canvas",
-            "Nova Reel",
+            "Stability Image Ultra",
+            "Claude Opus",
             "Composio v3 API",
-            "Cloudinary",
             "GitHub Actions"
          ],
          "features": [
-            "Daily 9 AM IST cron - topic + caption + image prompt via Bedrock Claude",
-            "Premium 1024x1024 AI images via Nova Canvas (cfgScale 9.0, aggressive negative prompts)",
-            "6-second Reels via Bedrock Nova Reel (async S3 output) for reel-format pillars",
-            "Day-of-week content pillars (Cognitive Biases, Relationship Psychology, Habits) configurable via config.json"
+            "Daily cron publishes live - topic + caption + image prompts via Bedrock Claude",
+            "Premium AI image carousels via Stability Image Ultra with negative prompts",
+            "Content-filter resilience: skips filtered slides, publishes when 2+ survive",
+            "Dedup history committed back to repo, wide-niche content pillars via config.json"
          ],
          "github": "https://github.com/Sagargupta16/instagram-autopilot",
          "live": ""
@@ -351,7 +350,7 @@
       {
          "id": 19,
          "title": "Financial Dashboard",
-         "description": "The original Excel-upload financial dashboard (v0.5.0) that evolved into Ledger Sync. Built with React + TypeScript, featuring Chart.js visualizations, 50/30/20 budgeting, tax planning, and lifestyle analytics. Now superseded - see Ledger Sync for the production-ready successor.",
+         "description": "The original Excel-upload financial dashboard that evolved into Ledger Sync. Built with React + TypeScript, featuring Chart.js visualizations, 50/30/20 budgeting, tax planning, and lifestyle analytics. Now superseded - see Ledger Sync for the production-ready successor.",
          "date": "February 2026",
          "tools_tech": [
             "TypeScript",
@@ -436,26 +435,6 @@
          "live": ""
       },
       {
-         "id": 25,
-         "title": "GroundZeroNN",
-         "description": "A neural network library built from scratch in Python - no TensorFlow, no PyTorch - with working backpropagation and 79.8% MNIST accuracy in under 3 minutes. Implements forward/backward propagation, ReLU/Sigmoid/Softmax activations, He/Xavier initializers, and SGD optimizer - pure NumPy.",
-         "date": "February 2025",
-         "tools_tech": [
-            "Python",
-            "NumPy",
-            "Deep Learning",
-            "Matplotlib"
-         ],
-         "features": [
-            "79.8% MNIST test accuracy in 2.7 min (parallel batch) - zero ML frameworks",
-            "Forward + backward propagation, weight updates, gradient descent",
-            "ReLU / Sigmoid / Softmax activations, He Normal / Xavier initializers",
-            "Softmax + Cross-Entropy for multi-class classification, MSE for regression"
-         ],
-         "github": "https://github.com/Sagargupta16/GroundZeroNN",
-         "live": ""
-      },
-      {
          "id": 11,
          "title": "Brainstorm Verse",
          "description": "A modern idea-sharing platform built with Next.js 14 App Router where creativity meets collaboration. Threaded comments, personalized user profiles, secure Clerk authentication, and file uploads via UploadThing.",
@@ -499,7 +478,7 @@
             "CORS-enabled, server-side Joi schema validation, React Router frontend"
          ],
          "github": "https://github.com/Sagargupta16/Authentication-System",
-         "live": "https://authentication-system-wmta.onrender.com/"
+         "live": ""
       },
       {
          "id": 4,
@@ -521,7 +500,7 @@
             "Zero-refresh SPA navigation with React Router 7"
          ],
          "github": "https://github.com/Sagargupta16/Contact-Manager-Mern",
-         "live": "https://contact-manager-mern-cg19.onrender.com/"
+         "live": "https://sagargupta.online/Contact-Manager-Mern/"
       },
       {
          "id": 5,
@@ -652,8 +631,8 @@
       {
          "id": 38,
          "title": "Claude Skills",
-         "description": "Custom Claude Code plugin marketplace (v4.2.0) with 25 reusable plugins, 29 agents, 9 hooks, and ~28 slash commands covering full-stack development, testing, API design, databases, CI/CD, Docker, security, performance, logging, refactoring, documentation, git workflows, open source contributions, and more. Installable via /plugin marketplace.",
-         "date": "March 2026",
+         "description": "Custom Claude Code plugin marketplace (v5.1.0) with 16 curated plugins covering dev workflow, testing, CI/CD, Docker, refactoring, git workflows, open source contributions, Python clean code, animation, and more. Installable via /plugin marketplace.",
+         "date": "June 2026",
          "tools_tech": [
             "Claude Code",
             "Plugin Marketplace",
@@ -662,9 +641,9 @@
             "GitHub Actions"
          ],
          "features": [
-            "25 plugins with 25 skills, 29 agents, 9 hooks, ~28 slash commands",
-            "Stack-specific plugins (farm-stack, testing, api-design, database, ci-cd, docker-deploy)",
-            "Workflow and meta plugins (methodology, context-management, session-management, planning, verification)",
+            "16 curated plugins spanning agents, hooks, skills, and slash commands",
+            "Stack-specific plugins (farm-stack, ci-cd, docker-deploy, deps-audit, repo-polish)",
+            "clean-code (Python Clean Code catalog) and motion (animation audit/add/fix) plugins",
             "CI validation pipeline and tiered installation guide"
          ],
          "github": "https://github.com/Sagargupta16/claude-skills",
@@ -695,7 +674,7 @@
       {
          "id": 43,
          "title": "Bedrock Multi-Model MCP",
-         "description": "MCP server for AWS Bedrock - text, image, and video generation across Llama 4, Mistral, Nova, Cohere, DeepSeek, Stable Diffusion 3.5, and Claude. Use any Bedrock model from Claude Code or any MCP client. Supports bearer token auth and side-by-side model comparison.",
+         "description": "MCP server for AWS Bedrock - text, image, video generation, and embeddings across Llama 4, Mistral, Nova, Cohere, DeepSeek, Qwen, GPT-OSS, Stable Diffusion 3.5, and Claude. Use any Bedrock model from Claude Code or any MCP client. Supports bearer token auth and side-by-side model comparison.",
          "date": "April 2026",
          "tools_tech": [
             "TypeScript",
@@ -737,7 +716,7 @@
       {
          "id": 35,
          "title": "Claude Code Recipes",
-         "description": "50+ copy-paste recipes for Claude Code covering 12 commands, 9 subagents, 5 hooks, and MCP configs. Every recipe works out of the box - just drop into your .claude/ folder and use immediately.",
+         "description": "47 copy-paste recipes for Claude Code covering 12 commands, 9 subagents, 5 hooks, and MCP configs. Every recipe works out of the box - just drop into your .claude/ folder and use immediately.",
          "date": "March 2026",
          "tools_tech": [
             "Claude Code",
@@ -926,33 +905,27 @@
          "status": "open"
       },
       {
-         "repo": "modelcontextprotocol/python-sdk",
-         "title": "Add subject field to AccessToken for auth",
-         "url": "https://github.com/modelcontextprotocol/python-sdk/pull/2446",
-         "status": "open"
-      },
-      {
          "repo": "awslabs/agent-plugins",
          "title": "Fix: check file extension before defusedxml dependency",
          "url": "https://github.com/awslabs/agent-plugins/pull/132",
-         "status": "open"
+         "status": "merged"
       },
       {
          "repo": "awslabs/agent-plugins",
-         "title": "Fix: shorten MCP server names for Bedrock 64-char limit",
-         "url": "https://github.com/awslabs/agent-plugins/pull/133",
+         "title": "Quote CLAUDE_PLUGIN_ROOT in hook commands to support paths with spaces",
+         "url": "https://github.com/awslabs/agent-plugins/pull/212",
          "status": "open"
       },
       {
-         "repo": "aws/aws-cdk",
-         "title": "Scope batch SubmitJob IAM to specific resources",
-         "url": "https://github.com/aws/aws-cdk/pull/37601",
+         "repo": "modelcontextprotocol/servers",
+         "title": "Normalize git_log schema across filtered and unfiltered branches",
+         "url": "https://github.com/modelcontextprotocol/servers/pull/4470",
          "status": "open"
       },
       {
-         "repo": "aws/aws-cdk",
-         "title": "Fix: apply timeout to FileDefinitionBody and StringDefinitionBody",
-         "url": "https://github.com/aws/aws-cdk/pull/37602",
+         "repo": "awslabs/mcp",
+         "title": "Accept skill-type results in search_documentation",
+         "url": "https://github.com/awslabs/mcp/pull/4076",
          "status": "open"
       }
    ],

--- a/data/services.json
+++ b/data/services.json
@@ -60,7 +60,7 @@
       "list": [
          "Algorithm Design & Analysis",
          "Dynamic Programming",
-         "2000+ Problems Solved",
+         "1600+ Problems Solved",
          "LeetCode Knight Rating",
          "Contest Strategy & Mentoring"
       ]

--- a/data/skills.json
+++ b/data/skills.json
@@ -7,6 +7,8 @@
       "Java",
       "SQL",
       "HCL",
+      "Bash",
+      "Go",
       "C#",
       "R",
       "HTML/CSS"
@@ -19,7 +21,7 @@
       "Three.js",
       "Motion",
       "Redux",
-      "Material-UI"
+      "MUI"
    ],
    "backend": [
       "Node.js",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
    "devDependencies": {
       "@eslint/js": "^9.39.4",
       "@testing-library/react": "^16.3.2",
+      "@types/react": "^19.2.14",
       "@types/react-dom": "^19.2.3",
+      "@types/three": "^0.185.0",
       "@vitejs/plugin-react": "^6.0.3",
       "eslint": "^9.39.4",
       "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/package.json
+++ b/package.json
@@ -71,18 +71,5 @@
    "license": "GPL-3.0",
    "bugs": {
       "url": "https://github.com/Sagargupta16/portfolio-react/issues"
-   },
-   "pnpm": {
-      "overrides": {
-         "@isaacs/brace-expansion": ">=5.0.1",
-         "minimatch": ">=10.2.3",
-         "js-yaml": ">=4.1.1",
-         "ajv@<7": "~6.14.0",
-         "rollup@>=4.0.0 <4.59.0": ">=4.59.0",
-         "undici": ">=7.28.0 <8",
-         "flatted": ">=3.4.0",
-         "yaml": ">=2.8.3",
-         "esbuild": ">=0.28.1"
-      }
    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,17 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@isaacs/brace-expansion': '>=5.0.1'
+  minimatch: '>=10.2.3'
+  js-yaml: '>=4.1.1'
+  ajv@<7: ~6.14.0
+  rollup@>=4.0.0 <4.59.0: '>=4.59.0'
+  undici: '>=7.28.0 <8'
+  flatted: '>=3.4.0'
+  yaml: '>=2.8.3'
+  esbuild: '>=0.28.1'
+
 importers:
 
   .:
@@ -1058,9 +1069,6 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1075,9 +1083,6 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
-
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1145,9 +1150,6 @@ packages:
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1990,9 +1992,6 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2573,7 +2572,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.3.0
-      esbuild: ^0.27.0 || ^0.28.0
+      esbuild: '>=0.28.1'
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -2582,7 +2581,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3025,7 +3024,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.5
+      minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
 
@@ -3046,7 +3045,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.3.0
-      minimatch: 3.1.5
+      minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -3641,8 +3640,6 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -3652,11 +3649,6 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-
-  brace-expansion@1.1.15:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
 
   brace-expansion@5.0.6:
     dependencies:
@@ -3727,8 +3719,6 @@ snapshots:
   commander@13.1.0: {}
 
   commondir@1.0.1: {}
-
-  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4067,7 +4057,7 @@ snapshots:
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 3.1.5
+      minimatch: 10.2.5
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -4099,7 +4089,7 @@ snapshots:
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.5
+      minimatch: 10.2.5
       object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
@@ -4153,7 +4143,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.5
+      minimatch: 10.2.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -4758,10 +4748,6 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
-
-  minimatch@3.1.5:
-    dependencies:
-      brace-expansion: 1.1.15
 
   minipass@7.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,17 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@isaacs/brace-expansion': '>=5.0.1'
-  minimatch: '>=10.2.3'
-  js-yaml: '>=4.1.1'
-  ajv@<7: ~6.14.0
-  rollup@>=4.0.0 <4.59.0: '>=4.59.0'
-  undici: '>=7.28.0 <8'
-  flatted: '>=3.4.0'
-  yaml: '>=2.8.3'
-  esbuild: '>=0.28.1'
-
 importers:
 
   .:
@@ -30,7 +19,7 @@ importers:
         version: 5.2.8
       '@react-three/drei':
         specifier: ^10.7.7
-        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.0))(@types/react@19.2.14)(@types/three@0.182.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.0)
+        version: 10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.0))(@types/react@19.2.14)(@types/three@0.185.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.0)
       '@react-three/fiber':
         specifier: ^9.6.1
         version: 9.6.1(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.0)
@@ -74,9 +63,15 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@types/three':
+        specifier: ^0.185.0
+        version: 0.185.0
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.0(esbuild@0.28.1)(jiti@2.7.0))
@@ -855,8 +850,8 @@ packages:
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
 
-  '@types/three@0.182.0':
-    resolution: {integrity: sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==}
+  '@types/three@0.185.0':
+    resolution: {integrity: sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==}
 
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
@@ -970,9 +965,6 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
-  '@webgpu/types@0.1.71':
-    resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1066,9 +1058,8 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  balanced-match@4.0.3:
-    resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
-    engines: {node: 20 || >=22}
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1085,9 +1076,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1155,6 +1145,9 @@ packages:
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1782,8 +1775,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.0:
-    resolution: {integrity: sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -1986,20 +1979,19 @@ packages:
     peerDependencies:
       three: '>=0.137'
 
-  meshoptimizer@0.22.0:
-    resolution: {integrity: sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==}
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -2581,7 +2573,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.3.0
-      esbuild: '>=0.28.1'
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -2590,7 +2582,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: '>=2.8.3'
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3033,7 +3025,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -3053,8 +3045,8 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 5.2.0
-      minimatch: 10.2.5
+      js-yaml: 4.3.0
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -3157,7 +3149,7 @@ snapshots:
 
   '@oxc-project/types@0.137.0': {}
 
-  '@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.0))(@types/react@19.2.14)(@types/three@0.182.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.0)':
+  '@react-three/drei@10.7.7(@react-three/fiber@9.6.1(@types/react@19.2.14)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.0))(@types/react@19.2.14)(@types/three@0.185.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(three@0.185.0)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@mediapipe/tasks-vision': 0.10.17
@@ -3169,10 +3161,10 @@ snapshots:
       detect-gpu: 5.0.70
       glsl-noise: 0.0.0
       hls.js: 1.6.16
-      maath: 0.10.8(@types/three@0.182.0)(three@0.185.0)
+      maath: 0.10.8(@types/three@0.185.0)(three@0.185.0)
       meshline: 3.3.1(three@0.185.0)
       react: 19.2.7
-      stats-gl: 2.4.2(@types/three@0.182.0)(three@0.185.0)
+      stats-gl: 2.4.2(@types/three@0.185.0)(three@0.185.0)
       stats.js: 0.17.0
       suspend-react: 0.1.3(react@19.2.7)
       three: 0.185.0
@@ -3390,15 +3382,14 @@ snapshots:
 
   '@types/stats.js@0.17.4': {}
 
-  '@types/three@0.182.0':
+  '@types/three@0.185.0':
     dependencies:
       '@dimforge/rapier3d-compat': 0.12.0
       '@tweenjs/tween.js': 23.1.3
       '@types/stats.js': 0.17.4
       '@types/webxr': 0.5.24
-      '@webgpu/types': 0.1.71
       fflate: 0.8.3
-      meshoptimizer: 0.22.0
+      meshoptimizer: 1.1.1
 
   '@types/webxr@0.5.24': {}
 
@@ -3546,8 +3537,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@webgpu/types@0.1.71': {}
-
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -3652,7 +3641,7 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  balanced-match@4.0.3: {}
+  balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
@@ -3664,9 +3653,10 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@1.1.15:
     dependencies:
-      balanced-match: 4.0.3
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.6:
     dependencies:
@@ -3737,6 +3727,8 @@ snapshots:
   commander@13.1.0: {}
 
   commondir@1.0.1: {}
+
+  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4075,7 +4067,7 @@ snapshots:
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 10.2.5
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -4107,7 +4099,7 @@ snapshots:
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
-      minimatch: 10.2.4
+      minimatch: 3.1.5
       object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
@@ -4161,7 +4153,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 10.2.5
+      minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -4582,7 +4574,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -4733,9 +4725,9 @@ snapshots:
 
   lz-string@1.5.0: {}
 
-  maath@0.10.8(@types/three@0.182.0)(three@0.185.0):
+  maath@0.10.8(@types/three@0.185.0)(three@0.185.0):
     dependencies:
-      '@types/three': 0.182.0
+      '@types/three': 0.185.0
       three: 0.185.0
 
   magic-string@0.30.21:
@@ -4756,20 +4748,20 @@ snapshots:
     dependencies:
       three: 0.185.0
 
-  meshoptimizer@0.22.0: {}
+  meshoptimizer@1.1.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.5
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
 
   minipass@7.1.3: {}
 
@@ -5141,9 +5133,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  stats-gl@2.4.2(@types/three@0.182.0)(three@0.185.0):
+  stats-gl@2.4.2(@types/three@0.185.0)(three@0.185.0):
     dependencies:
-      '@types/three': 0.182.0
+      '@types/three': 0.185.0
       three: 0.185.0
 
   stats.js@0.17.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,13 @@
 allowBuilds:
   esbuild: true
+
+overrides:
+  "@isaacs/brace-expansion": ">=5.0.1"
+  minimatch: ">=10.2.3"
+  js-yaml: ">=4.1.1"
+  "ajv@<7": "~6.14.0"
+  "rollup@>=4.0.0 <4.59.0": ">=4.59.0"
+  undici: ">=7.28.0 <8"
+  flatted: ">=3.4.0"
+  yaml: ">=2.8.3"
+  esbuild: ">=0.28.1"

--- a/scripts/sync-credly.js
+++ b/scripts/sync-credly.js
@@ -63,7 +63,8 @@ function getBadgeType(badge) {
 }
 
 function transformBadge(badge, id) {
-   const name = badge.badge_template?.name || "";
+   // Credly badge names carry en/em dashes; house style forbids them
+   const name = (badge.badge_template?.name || "").replace(/[–—]/g, "-");
    const type = getBadgeType(badge);
    const entry = {
       id,

--- a/src/components/layout/Header/HeroContent.tsx
+++ b/src/components/layout/Header/HeroContent.tsx
@@ -7,7 +7,7 @@ import { MONO_FONT, GREEN } from "@/constants/theme";
 import HeroStats from "./HeroStats";
 import HeroSocial from "./HeroSocial";
 const RESUME_URL =
-   "https://github.com/Sagargupta16/latex-resume/releases/download/latest/resume.pdf";
+   "https://github.com/Sagargupta16/latex-resume/releases/latest/download/resume.pdf";
 
 const HeroContent = () => {
    const [roleIndex, setRoleIndex] = useState(0);


### PR DESCRIPTION
## Summary

Freshness pass driven by a 5-agent audit of data files vs live GitHub state, FACTS.md, and link checks. Verdict was MAJOR DRIFT: 8 visitor-visible wrong facts.

## Critical fixes

- **Dead links**: Contact Manager live -> GH Pages mirror (Render 404s), Authentication System Render link dropped (503), GroundZeroNN entry removed (repo private + archived)
- **Stale versions**: Ledger Sync v2.9.0 -> v2.19.0 with the July 2026 feature set (budget, bill calendar, GST, subscriptions, year-in-review); Claude Skills v4.2.0/25-plugins -> v5.1.0/16-plugins
- **False claim**: Instagram Autopilot Reels claim removed (Reels disabled 2026-07-04, carousel-only now); rewritten around the live daily-publishing pipeline
- **FACTS.md violations**: services.json 2000+ -> 1600+ problems, contests 140+ -> 100+, predictor 121K -> 244K records

## Also

- experience: canonical AWS title order, paired 50+/135+ figures, security-control units named
- skills: +Bash +Go, Material-UI -> MUI; education: BCA CGPA 7.34
- achievements: Kick Start dates aligned to FACTS.md; en-dashes stripped AND sync-credly.js patched so the weekly sync doesn't reintroduce them
- open_source_contributions refreshed to the current PR set (3 new 2026-07 PRs added, closed ones relabeled)
- toolchain: pnpm-workspace.yaml placeholder fixed, @types/react + @types/three added (post-Node-26 upgrade), .remember/ gitignored

## Testing

- tsc --noEmit clean, eslint 0 warnings, vitest 4/4, vite build green
- All JSON validated; 0 em/en dashes across all data files