### PR TITLE
docs: add merged axios PR to open source contributions

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -838,6 +838,12 @@
    ],
    "open_source_contributions": [
       {
+         "repo": "axios/axios",
+         "title": "Synthesize AxiosError message from AggregateError on dual-stack connection failures",
+         "url": "https://github.com/axios/axios/pull/11059",
+         "status": "merged"
+      },
+      {
          "repo": "feast-dev/feast",
          "title": "Add Claude Code agent skills for Feast",
          "url": "https://github.com/feast-dev/feast/pull/6081",


### PR DESCRIPTION
Adds [axios/axios#11059](https://github.com/axios/axios/pull/11059) (merged into v1.x, 2026-07-13) to the open_source_contributions list in projects.json, as the first entry.

Core bugfix: synthesizes the AxiosError message from AggregateError.errors so dual-stack connection failures surface actionable detail. 109K-star project. Keeps the portfolio in sync with the resume (latex-resume #11) and profile README.