### PR TITLE
feat: bricolage grotesque display headings with two-tone hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented here. Follows [Semantic Versioning](https://semver.org/).
 
+## [4.2.0] - 2026-07-18
+
+### Changed
+
+- **Display typography**: hero headline and section titles now use Bricolage Grotesque (variable, self-hosted via Fontsource, ~41 kB latin subset) at weight 800 with -0.03em tracking via a new `.display-heading` class and `--font-display` token. Body text stays Inter, mono stays JetBrains Mono.
+- Hero headline hierarchy: name accented in light blue, second line ("Shipping cloud at scale.") dimmed to secondary -- two-tone replaces the flat all-white treatment.
+
 ## [4.1.0] - 2026-07-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "portfolio-react",
-   "version": "4.1.0",
+   "version": "4.2.0",
    "type": "module",
    "private": true,
    "homepage": "https://sagargupta.online/portfolio-react/",
@@ -21,6 +21,7 @@
    },
    "dependencies": {
       "@emailjs/browser": "^4.4.1",
+      "@fontsource-variable/bricolage-grotesque": "^5.3.0",
       "@fontsource-variable/inter": "^5.2.8",
       "@fontsource-variable/jetbrains-mono": "^5.2.8",
       "@tailwindcss/vite": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       '@emailjs/browser':
         specifier: ^4.4.1
         version: 4.4.1
+      '@fontsource-variable/bricolage-grotesque':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
@@ -491,6 +494,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/bricolage-grotesque@5.3.0':
+    resolution: {integrity: sha512-TLi9Q4hJjS2UvoTMRSS2nHu6c4R56lAw60NR9QYtVRCHn0XtsFpiEhNffZ8Glsoxu6wEEwLKBP8lb94J52PNBA==}
 
   '@fontsource-variable/inter@5.2.8':
     resolution: {integrity: sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==}
@@ -3085,6 +3091,8 @@ snapshots:
       tabbable: 6.5.0
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/bricolage-grotesque@5.3.0': {}
 
   '@fontsource-variable/inter@5.2.8': {}
 

--- a/src/components/layout/Header/HeroContent.tsx
+++ b/src/components/layout/Header/HeroContent.tsx
@@ -4,7 +4,7 @@ import { useLenis } from "lenis/react";
 import { FileText } from "lucide-react";
 import { getName, getRoles } from "@data/dataLoader";
 import { staggerContainer, staggerItem } from "@utils/animations";
-import { GREEN, TEXT_SECONDARY } from "@/constants/theme";
+import { CYAN, GREEN, TEXT_SECONDARY } from "@/constants/theme";
 import CvViewerModal from "@components/ui/CvViewerModal/CvViewerModal";
 import HeroStats from "./HeroStats";
 import HeroSocial from "./HeroSocial";
@@ -81,14 +81,17 @@ const HeroContent = () => {
             </span>
          </motion.div>
 
-         {/* Heading */}
+         {/* Heading: display face, name in accent, second line dimmed for
+             hierarchy (both lines equally bright read flat) */}
          <motion.h1
-            className="text-5xl sm:text-6xl md:text-7xl font-semibold leading-[1.15] tracking-tight text-text-primary"
+            className="display-heading text-5xl sm:text-6xl md:text-7xl leading-[1.12] text-text-primary"
             variants={staggerItem}
          >
-            Hi, I&apos;m {name}.
+            Hi, I&apos;m <span style={{ color: CYAN }}>{name}</span>.
             <br />
-            Shipping cloud at scale.
+            <span style={{ color: "var(--color-text-secondary)" }}>
+               Shipping cloud at scale.
+            </span>
          </motion.h1>
 
          {/* Animated role cycling */}

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -24,10 +24,9 @@ const SectionHeader = ({ title, subtitle }: Props) => {
       >
          {subtitle && <span className="badge-pill">{subtitle}</span>}
          <h2
+            className="display-heading"
             style={{
                fontSize: "clamp(1.75rem, 4vw, 2.5rem)",
-               fontWeight: 600,
-               letterSpacing: "-0.02em",
                lineHeight: 1.2,
                color: "var(--color-text-primary)",
                maxWidth: 640,

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,12 @@
    --font-sans: "Inter Variable", "Inter", system-ui, -apple-system, sans-serif;
    --font-mono:
       "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, monospace;
+   /* Display face for the hero headline + section titles ONLY -- body stays
+      Inter. This heading/body pairing is what keeps the big type from reading
+      as a Tailwind default. */
+   --font-display:
+      "Bricolage Grotesque Variable", "Bricolage Grotesque", "Inter Variable",
+      system-ui, sans-serif;
 
    --color-bg-primary: #0b1012;
    --color-bg-secondary: #0e1418;
@@ -289,6 +295,13 @@ img {
       black 30%,
       transparent 75%
    );
+}
+
+/* ===== Display Headings (Bricolage Grotesque) ===== */
+.display-heading {
+   font-family: var(--font-display);
+   font-weight: 800;
+   letter-spacing: -0.03em;
 }
 
 /* ===== Solid Accent Text (gradient-text kept as compat alias) ===== */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "@fontsource-variable/inter";
 import "@fontsource-variable/jetbrains-mono";
+import "@fontsource-variable/bricolage-grotesque";
 import App from "./App";
 import "./index.css";
 


### PR DESCRIPTION
## Summary

The hero headline and section titles read as default Tailwind Inter. This adds a display face -- Bricolage Grotesque -- for headings only (body stays Inter, mono stays JetBrains Mono), plus a two-tone hero treatment: name accented in light blue, second line dimmed to secondary. Heading/body font pairing is the single highest-leverage change against the "looks like a template" problem.

## Changes

- `@fontsource-variable/bricolage-grotesque` (self-hosted like the other two faces; ~41 kB latin woff2 in the bundle)
- New `--font-display` theme token + `.display-heading` class (weight 800, -0.03em tracking)
- Hero h1 and `SectionHeader` h2 switched to the display face
- Hero two-tone: "Sagar Gupta" in accent blue (theme CYAN), "Shipping cloud at scale." in secondary grey
- v4.2.0 + CHANGELOG entry

## Type

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] content: Data update (`data/*.json`)
- [ ] refactor: Code restructuring
- [ ] chore: Maintenance / dependency update
- [ ] docs: Documentation only

## Testing

- [x] `pnpm lint` passes (zero warnings)
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes
- [x] `pnpm type-check` passes
- [x] Visually verified in browser

## Checklist

- [x] No hardcoded content in components (data belongs in `data/*.json`)
- [x] Theme constants used (no hardcoded colors/fonts)
- [ ] Reduced motion respected where applicable (motion always plays, by owner preference)
- [x] Mobile responsive

## Notes for review

- Verified live: `document.fonts.check` confirms the variable font loads; hero h1 and section h2s compute to "Bricolage Grotesque Variable" at weight 800
- No gradient text, no glow -- stays within the v4 aesthetic contract; this is a font swap + color hierarchy only
