### PR TITLE
fix(deps): declare esbuild explicitly to survive Vite 8 lockfile churn

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
       "@types/react": "^19.2.14",
       "@types/react-dom": "^19.2.3",
       "@vitejs/plugin-react": "^6.0.3",
+      "esbuild": "^0.28.1",
       "eslint": "^9.39.4",
       "eslint-plugin-jsx-a11y": "^6.10.2",
       "eslint-plugin-react": "^7.37.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.0(esbuild@0.28.1)(jiti@2.7.0))
       esbuild:
-        specifier: ^0.28.1
+        specifier: '>=0.28.1'
         version: 0.28.1
       eslint:
         specifier: ^9.39.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.0(esbuild@0.28.1)(jiti@2.7.0))
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -4086,7 +4089,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
-    optional: true
 
   escalade@3.2.0: {}
 


### PR DESCRIPTION
## Problem

The lockfile-maintenance PR (#195) bumps Vite 8.1.0 -> 8.1.5, which **breaks `pnpm build`**:

```
Error: Cannot find package 'esbuild' imported from vite/dist/node/chunks/node.js
error during build: Failed to load transformWithEsbuild
```

## Root cause

- `vite.config.js` uses `build.minify: "esbuild"`.
- Vite 8.1.x moved to Rolldown/Oxc and **no longer pulls esbuild in transitively**.
- `esbuild` was never a declared dependency, so it only survived on `main` as a transitive of vite 8.1.0. Any lockfile update that drops that transitive copy breaks the build.
- This is a latent fragility on `main` today, exposed by the pending Vite bump.

## Fix

Declare `esbuild` as an explicit devDependency (per Vite's own deprecation guidance). `minify: "esbuild"` remains fully supported in Vite 8 -- only the transform helper is deprecated, not the minifier -- so behavior is unchanged.

## Verify

- `pnpm build` -> ok
- `pnpm type-check` -> ok
- `pnpm test` -> 4/4 pass

Unblocks the deferred lockfile-maintenance PR once merged.