### PR TITLE
feat: surface aws-samples SageMaker MLOps publication

### DIFF
--- a/data/experience.json
+++ b/data/experience.json
@@ -56,12 +56,13 @@
                ]
             },
             {
-               "name": "Medical Image Classification MLOps Pipeline (Internal - SME Program)",
+               "name": "Medical Image Classification MLOps Pipeline (SME Program)",
                "date": "Jun 2025 - Aug 2025",
                "description": {
                   "1": "Architected end-to-end MLOps pipeline on SageMaker, automating data processing, multi-model training, and ensemble model creation for medical image classification.",
                   "2": "Deployed production SageMaker endpoints with blue-green deployment, auto-scaling, and drift detection - enabling zero-downtime model updates with automatic rollback.",
-                  "3": "Provisioned entire infrastructure with Terraform and built CI/CD via CodePipeline and CodeBuild, deploying CloudFront frontend and API Gateway + Lambda inference API."
+                  "3": "Provisioned entire infrastructure with Terraform and built CI/CD via CodePipeline and CodeBuild, deploying CloudFront frontend and API Gateway + Lambda inference API.",
+                  "4": "Generalized and published by AWS as an official sample under the aws-samples organization (MIT-0) - 89 Terraform files across 4 stacks and 14 reusable modules, with clinical quality gates, closed-loop drift retraining, and responsible-AI safeguards (Clarify bias reports, Model Cards, Bedrock Guardrails, A2I review)."
                },
                "skills": [
                   "AWS",
@@ -74,7 +75,9 @@
                   "CloudFront",
                   "Terraform",
                   "Python"
-               ]
+               ],
+               "link": "https://github.com/aws-samples/sample-sagemaker-image-classification-mlops",
+               "linkLabel": "aws-samples"
             },
             {
                "name": "DevOps Consultant - State Street",

--- a/data/projects.json
+++ b/data/projects.json
@@ -1,6 +1,34 @@
 {
    "featured_projects": [
       {
+         "id": 49,
+         "title": "SageMaker Image Classification MLOps",
+         "description": "Published by AWS under the aws-samples organization (MIT-0) - an end-to-end, production-shaped MLOps pipeline for image classification on Amazon SageMaker, declared entirely in Terraform across 89 files and 14 reusable modules. Event-driven ingestion, multi-architecture training behind hard clinical quality gates, human-approved governed deployment, and a closed drift-to-retrain loop. The worked example classifies medical images, but the architecture is domain-agnostic.",
+         "date": "July 2026",
+         "tools_tech": [
+            "Terraform",
+            "Amazon SageMaker",
+            "SageMaker Pipelines",
+            "Python",
+            "TensorFlow",
+            "AWS Lambda",
+            "EventBridge",
+            "CodePipeline",
+            "Amazon Bedrock"
+         ],
+         "features": [
+            "Terraform owns every persistent resource - endpoint, auto-scaling, monitors, alarms; Lambda orchestrates only, never mutates infrastructure",
+            "Three architectures (VGG16, DenseNet121, EfficientNetV2M) trained in parallel with two-phase transfer learning, then ensembled",
+            "Clinical quality gate as a hard pipeline condition - accuracy >= 0.85, recall >= 0.95, precision >= 0.80, AUC >= 0.90, or the model is never registered",
+            "Closed-loop retraining: Model Monitor drift alarm triggers EventBridge, which restarts training; human approval still gates every deployment",
+            "Responsible AI built in - SageMaker Clarify bias/explainability reports, Model Cards, Bedrock Guardrails, and A2I human review",
+            "Security scanning clean: 0 checkov failed checks and 0 bandit issues, every suppression documented with a reason"
+         ],
+         "github": "https://github.com/aws-samples/sample-sagemaker-image-classification-mlops",
+         "live": "",
+         "organization": "aws-samples"
+      },
+      {
          "id": 44,
          "title": "Kalchar",
          "description": "Production folk-art portfolio and commission site for a traditional artist - Madhubani, Pichwai, Lippan, and Gond artwork gallery with a buy filter, events, workshops, custom orders, and a server-rendered admin panel. Public pages are static, catalog lives in Neon Postgres behind a single data seam, and artwork images are served from Cloudflare R2.",

--- a/src/pages/experience/ModalProjectCard.tsx
+++ b/src/pages/experience/ModalProjectCard.tsx
@@ -10,6 +10,7 @@ import {
    EASING,
 } from "@/constants/theme";
 import type { ExperienceProject } from "@/types";
+import ProjectSourceLink from "./ProjectSourceLink";
 
 interface ModalProjectCardProps {
    project: ExperienceProject;
@@ -108,6 +109,14 @@ const ModalProjectCard = ({ project, index }: ModalProjectCardProps) => (
             <TechTag key={s} label={s} accent={CYAN} size={10} />
          ))}
       </div>
+      {project.link && (
+         <ProjectSourceLink
+            href={project.link}
+            label={project.linkLabel}
+            projectName={project.name}
+            accentColor={CYAN}
+         />
+      )}
    </motion.div>
 );
 

--- a/src/pages/experience/ProjectSourceLink.tsx
+++ b/src/pages/experience/ProjectSourceLink.tsx
@@ -1,0 +1,51 @@
+import { ExternalLink } from "lucide-react";
+import { MONO_FONT } from "@/constants/theme";
+
+interface ProjectSourceLinkProps {
+   href: string;
+   /** Short label, e.g. the org the artifact is published under. */
+   label?: string;
+   /** Project name, used for the accessible label only. */
+   projectName: string;
+   accentColor: string;
+}
+
+/**
+ * Link to the public artifact of a piece of work, for the projects inside an
+ * experience entry. Most client work has none; the ones that do are the strongest
+ * evidence on the page, so the link sits on the claim rather than in a separate
+ * section.
+ */
+const ProjectSourceLink = ({
+   href,
+   label = "Source",
+   projectName,
+   accentColor,
+}: ProjectSourceLinkProps) => (
+   <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`View ${projectName} source on GitHub`}
+      style={{
+         display: "inline-flex",
+         alignItems: "center",
+         gap: 5,
+         marginTop: 10,
+         padding: "5px 10px",
+         borderRadius: 8,
+         border: `1px solid ${accentColor}40`,
+         background: `${accentColor}12`,
+         color: accentColor,
+         fontFamily: MONO_FONT,
+         fontSize: 10,
+         lineHeight: 1.4,
+         textDecoration: "none",
+      }}
+   >
+      <ExternalLink size={11} style={{ flexShrink: 0 }} />
+      {label}
+   </a>
+);
+
+export default ProjectSourceLink;

--- a/src/pages/experience/TimelineExpandedContent.tsx
+++ b/src/pages/experience/TimelineExpandedContent.tsx
@@ -3,6 +3,7 @@ import { FolderGit2 } from "lucide-react";
 import type { ProfessionalExperience, PositionOfResponsibility } from "@/types";
 import { TEXT_MUTED } from "@/constants/theme";
 import { BulletList, SkillTags } from "./experienceHelpers";
+import ProjectSourceLink from "./ProjectSourceLink";
 import { FADE_ENTRY } from "./experienceConstants";
 
 interface TimelineExpandedContentProps {
@@ -78,6 +79,14 @@ const TimelineExpandedContent = ({
                            skills={project.skills}
                            accentColor={accentColor}
                            extraStyle={{ marginTop: 12 }}
+                        />
+                     )}
+                     {project.link && (
+                        <ProjectSourceLink
+                           href={project.link}
+                           label={project.linkLabel}
+                           projectName={project.name}
+                           accentColor={accentColor}
                         />
                      )}
                   </motion.div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -102,6 +102,10 @@ export interface ExperienceProject {
    date?: string;
    description: Record<string, string>;
    skills: string[];
+   /** Public artifact of this work, when one exists (e.g. a published sample repo). */
+   link?: string;
+   /** Short label for the link, defaults to "Source" when omitted. */
+   linkLabel?: string;
 }
 
 export interface InternalContribution {


### PR DESCRIPTION
AWS published the SME-program MLOps pipeline as an official sample under the
[aws-samples](https://github.com/aws-samples/sample-sagemaker-image-classification-mlops)
org (MIT-0). The work is public now, so it should read that way here.

## What changed

**`data/projects.json`** -- new lead featured project. Copy is grounded in the actual repo (README + file tree), not the internal bullet: 89 Terraform files, 14 modules, VGG16/DenseNet121/EfficientNetV2M, the real quality-gate thresholds, checkov/bandit clean.

**`data/experience.json`** -- dropped the `Internal -` prefix from the SME project name (no longer true) and added a 4th description line plus a `link` to the repo.

**`src/types/index.ts` + `ProjectSourceLink.tsx`** -- `ExperienceProject` had no way to point at a public artifact. Added optional `link`/`linkLabel` and a small chip component, wired into both render paths (`ModalProjectCard`, `TimelineExpandedContent`).

Placement note: this is an authored solution AWS published, not an upstream patch, so it does not belong in the open-source contributions section.

## Verification

- `pnpm type-check`, `pnpm lint` (zero-warnings), `pnpm test` (4/4) all pass
- `prettier --check` clean on every touched file. Deliberately did not run the formatter across `data/projects.json` -- it carries pre-existing drift on `main` and a full pass would add ~140 lines of unrelated churn
- Verified live in the dev server: link renders in the experience modal as an `aws-samples` chip, correct href, `target=_blank` + `rel="noopener noreferrer"`, blue accent (`rgb(96,165,250)`), JetBrains Mono