### PR TITLE
feat: add kinfolk and orbit, fix stale links and animated covers

### DIFF
--- a/data/personal.json
+++ b/data/personal.json
@@ -26,10 +26,10 @@
    "statistics": {
       "coding_questions": "1600+",
       "leetcode_rating": "2007",
-      "projects": "40+",
+      "projects": "44+",
       "contests": "100+",
       "industry_certifications": "6",
-      "open_source_prs": "9 merged + 7 open"
+      "open_source_prs": "9 merged + 6 open"
    },
    "languages": [
       { "name": "English", "level": "Professional Working" },

--- a/data/projects.json
+++ b/data/projects.json
@@ -29,6 +29,32 @@
          "organization": "aws-samples"
       },
       {
+         "id": 50,
+         "title": "Kinfolk",
+         "description": "Collaborative family graph where relatives each keep their own record, invite each other, and join matching people without either side losing their copy. A family is modelled as a directed acyclic graph rather than a tree: parentage hangs off a union row, so remarriages, half-siblings, single parents, and adoption are ordinary data instead of renderer special cases. Cross-tree identity is a consent-gated link, so merging is non-destructive and an unlink restores both original views.",
+         "date": "August 2026",
+         "tools_tech": [
+            "Next.js 16",
+            "TypeScript",
+            "Neon Postgres",
+            "Drizzle ORM",
+            "Auth.js v5",
+            "React Flow",
+            "ELK",
+            "Tailwind CSS 4"
+         ],
+         "features": [
+            "Family as a DAG: parentage hangs off a union row, so remarriages and adoption need no special cases",
+            "Consent-gated person links make cross-tree merging non-destructive and fully reversible",
+            "Union-find tree fusion with deterministic fused ids, so a combined graph is reproducible",
+            "Missing data is first-class: unknown is a stored value and approximate dates keep their own fields",
+            "Also a contact graph, where a friendship carries no generation and never reaches the layout engine",
+            "Contact values never render on cards or in their accessible labels"
+         ],
+         "github": "https://github.com/Sagargupta16/kinfolk",
+         "live": "https://sagargupta.online/kinfolk/"
+      },
+      {
          "id": 44,
          "title": "Kalchar",
          "description": "Production folk-art portfolio and commission site for a traditional artist - Madhubani, Pichwai, Lippan, and Gond artwork gallery with a buy filter, events, workshops, custom orders, and a server-rendered admin panel. Public pages are static, catalog lives in Neon Postgres behind a single data seam, and artwork images are served from Cloudflare R2.",
@@ -286,7 +312,7 @@
             "Subscription-based payments",
             "User registration and search"
          ],
-         "github": "https://github.com/Sagargupta16/TRINIT_BugBiters_Dev",
+         "github": "https://github.com/Sagargupta16/Lingua-Connect",
          "live": "",
          "team": "BugBiters",
          "organization": "TriNIT",
@@ -377,6 +403,30 @@
       }
    ],
    "other_projects": [
+      {
+         "id": 51,
+         "title": "Orbit",
+         "description": "Personal CRM for the people in your orbit: contacts, connections, and interaction history in a tabular relationship dashboard. FastAPI and SQLAlchemy 2 behind a React 19 frontend, with Google and GitHub OAuth against a live Neon Postgres database. The contacts surface is wired end to end; interactions, circles, and reminders are modelled in the schema and not yet exposed.",
+         "date": "July 2026",
+         "tools_tech": [
+            "FastAPI",
+            "Python 3.13",
+            "SQLAlchemy 2",
+            "Alembic",
+            "React 19",
+            "TypeScript",
+            "Vite",
+            "Neon Postgres"
+         ],
+         "features": [
+            "OAuth sign-in (Google and GitHub) with protected routes and a live Neon-backed API",
+            "Contacts dashboard wired to the backend, deployed to GitHub Pages",
+            "Alembic migrations over a SQLAlchemy 2 schema covering contacts, interactions, circles, and reminders",
+            "uv for Python and pnpm for the frontend, run together from root scripts"
+         ],
+         "github": "https://github.com/Sagargupta16/orbit",
+         "live": "https://sagargupta.online/orbit/"
+      },
       {
          "id": 46,
          "title": "Sagas",
@@ -724,8 +774,8 @@
       },
       {
          "id": 47,
-         "title": "ITR MCP",
-         "description": "Local-first MCP server for Indian income tax, published on npm. Deterministic tax computation, old-vs-new regime comparison, advance tax planning, and document parsing - all on your machine. The LLM never does arithmetic; every number comes from a versioned, auditable rule pack. Works with Claude Desktop, Claude Code, and any MCP client.",
+         "title": "ITR Agent",
+         "description": "Local-first MCP server that walks you through filing an Indian income tax return, published on npm. 12 tools spanning form selection, deterministic computation, old-vs-new regime comparison, advance tax planning, and document parsing - all on your machine. The LLM never does arithmetic; every number comes from a versioned, auditable rule pack. Works with Claude Desktop, Claude Code, and any MCP client.",
          "date": "July 2026",
          "tools_tech": [
             "TypeScript",
@@ -734,13 +784,14 @@
             "npm"
          ],
          "features": [
-            "compute_tax and compare_regimes with slab, cess, and surcharge handling",
-            "Advance tax planning and LTCG/STCG capital gains computation",
-            "Local document parsing - no accounts, no uploads, no cloud",
-            "Versioned rule packs so every figure is auditable"
+            "recommend_itr_form picks ITR-1/2/3/4 with rule-by-rule reasoning, including brought-forward losses that force ITR-3",
+            "file_my_itr guided interview plus a schedule-by-schedule filing checklist ending at e-verification",
+            "compute_tax covers FY 2025-26 slabs, 87A rebate with marginal relief, 111A/112A gains, surcharge caps, and cess",
+            "Reconciles Form 16 against AIS and 26AS to pre-empt 143(1)(a) intimations",
+            "AIS decrypt and parse happen on-device - no accounts, no uploads, no cloud"
          ],
-         "github": "https://github.com/Sagargupta16/itr-mcp",
-         "live": "https://www.npmjs.com/package/itr-mcp"
+         "github": "https://github.com/Sagargupta16/itr-agent",
+         "live": "https://www.npmjs.com/package/itr-agent"
       },
       {
          "id": 38,
@@ -1052,7 +1103,7 @@
          "repo": "awslabs/mcp",
          "title": "Accept skill-type results in search_documentation",
          "url": "https://github.com/awslabs/mcp/pull/4076",
-         "status": "open"
+         "status": "closed"
       }
    ],
    "community_discussions": [

--- a/src/pages/portfolio/covers/GraphScene.tsx
+++ b/src/pages/portfolio/covers/GraphScene.tsx
@@ -1,0 +1,269 @@
+import { motion } from "motion/react";
+import { MONO_FONT } from "@/constants/theme";
+
+interface CoverSceneProps {
+   tint: string;
+}
+
+/*
+ * Kinfolk: two family trees that turn out to share a person. Left tree is
+ * yours, right tree is a relative's, and the dashed link between the two
+ * matching nodes resolves into a solid join. That consent-gated merge is the
+ * whole product, so it gets the beat.
+ *
+ * Coordinates are viewBox units (0..100 x, 0..60 y) so the graph scales with
+ * the 16:10 slot instead of drifting on narrow cards.
+ */
+
+const CYCLE = 6.5;
+
+/* Left tree: a union with two children. Right tree: same shape, mirrored. */
+const LEFT = {
+   a: { x: 16, y: 15 },
+   b: { x: 34, y: 15 },
+   c1: { x: 13, y: 40 },
+   c2: { x: 31, y: 40 },
+   union: { x: 25, y: 24 },
+};
+const RIGHT = {
+   a: { x: 66, y: 15 },
+   b: { x: 84, y: 15 },
+   c1: { x: 69, y: 40 },
+   c2: { x: 87, y: 40 },
+   union: { x: 75, y: 24 },
+};
+
+/* The shared human: LEFT.b and RIGHT.a are the same person in both trees. */
+const SHARED_FROM = LEFT.b;
+const SHARED_TO = RIGHT.a;
+
+const label: React.CSSProperties = {
+   fontFamily: MONO_FONT,
+   fontSize: 6.5,
+   fontWeight: 700,
+   letterSpacing: "0.14em",
+   textTransform: "uppercase",
+};
+
+const Person = ({
+   cx,
+   cy,
+   tint,
+   delay,
+   highlight,
+}: {
+   cx: number;
+   cy: number;
+   tint: string;
+   delay: number;
+   highlight?: boolean;
+}) => (
+   <motion.circle
+      cx={cx}
+      cy={cy}
+      r={3.4}
+      fill={highlight ? `${tint}30` : `${tint}12`}
+      stroke={highlight ? tint : `${tint}55`}
+      strokeWidth={highlight ? 1.2 : 0.9}
+      vectorEffect="non-scaling-stroke"
+      initial={{ opacity: 0.55 }}
+      animate={{ opacity: highlight ? [0.6, 1, 0.6] : [0.5, 0.85, 0.5] }}
+      transition={{
+         duration: CYCLE,
+         repeat: Infinity,
+         delay,
+         times: [0, 0.3, 0.7],
+         ease: "easeInOut",
+      }}
+   />
+);
+
+/* Parentage hangs off the union node, never off a parent pair. */
+const Family = ({
+   t,
+   tint,
+   delay,
+   sharedKey,
+}: {
+   t: typeof LEFT;
+   tint: string;
+   delay: number;
+   sharedKey: "a" | "b";
+}) => (
+   <>
+      {/* partner bar into the union node */}
+      <path
+         d={`M ${t.a.x} ${t.a.y} L ${t.b.x} ${t.b.y}`}
+         stroke={`${tint}30`}
+         strokeWidth={0.8}
+         fill="none"
+         vectorEffect="non-scaling-stroke"
+      />
+      {/* union -> each child */}
+      <path
+         d={`M ${t.union.x} ${t.union.y} L ${t.union.x} ${t.union.y + 6} L ${t.c1.x} ${t.union.y + 6} L ${t.c1.x} ${t.c1.y}`}
+         stroke={`${tint}2e`}
+         strokeWidth={0.8}
+         fill="none"
+         vectorEffect="non-scaling-stroke"
+      />
+      <path
+         d={`M ${t.union.x} ${t.union.y} L ${t.union.x} ${t.union.y + 6} L ${t.c2.x} ${t.union.y + 6} L ${t.c2.x} ${t.c2.y}`}
+         stroke={`${tint}2e`}
+         strokeWidth={0.8}
+         fill="none"
+         vectorEffect="non-scaling-stroke"
+      />
+      {/* the union itself, drawn small so it reads as a joint not a person */}
+      <rect
+         x={t.union.x - 1.3}
+         y={t.union.y - 1.3}
+         width={2.6}
+         height={2.6}
+         rx={0.6}
+         fill={`${tint}45`}
+      />
+      <Person
+         cx={t.a.x}
+         cy={t.a.y}
+         tint={tint}
+         delay={delay}
+         highlight={sharedKey === "a"}
+      />
+      <Person
+         cx={t.b.x}
+         cy={t.b.y}
+         tint={tint}
+         delay={delay + 0.2}
+         highlight={sharedKey === "b"}
+      />
+      <Person cx={t.c1.x} cy={t.c1.y} tint={tint} delay={delay + 0.4} />
+      <Person cx={t.c2.x} cy={t.c2.y} tint={tint} delay={delay + 0.6} />
+   </>
+);
+
+const GraphScene = ({ tint }: CoverSceneProps) => (
+   <div
+      aria-hidden="true"
+      style={{
+         position: "absolute",
+         inset: 0,
+         overflow: "hidden",
+         background: `radial-gradient(ellipse at 50% 8%, ${tint}12 0%, transparent 60%), linear-gradient(160deg, #0e1a24 0%, #0b1012 60%)`,
+      }}
+   >
+      {/* dot grid for depth */}
+      <div
+         style={{
+            position: "absolute",
+            inset: 0,
+            opacity: 0.05,
+            backgroundImage:
+               "radial-gradient(rgba(255,255,255,0.6) 1px, transparent 1px)",
+            backgroundSize: "18px 18px",
+         }}
+      />
+
+      <svg
+         viewBox="0 0 100 60"
+         preserveAspectRatio="xMidYMid meet"
+         style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+         }}
+      >
+         <Family t={LEFT} tint={tint} delay={0} sharedKey="b" />
+         <Family t={RIGHT} tint={tint} delay={0.5} sharedKey="a" />
+
+         {/* the candidate match, dashed until both sides consent */}
+         <path
+            d={`M ${SHARED_FROM.x} ${SHARED_FROM.y} L ${SHARED_TO.x} ${SHARED_TO.y}`}
+            stroke={`${tint}2a`}
+            strokeWidth={1}
+            strokeDasharray="2 2"
+            fill="none"
+            vectorEffect="non-scaling-stroke"
+         />
+         {/* consent lands: the link resolves solid, then releases */}
+         <motion.path
+            d={`M ${SHARED_FROM.x} ${SHARED_FROM.y} L ${SHARED_TO.x} ${SHARED_TO.y}`}
+            stroke="#22c55e"
+            strokeWidth={1.4}
+            strokeLinecap="round"
+            fill="none"
+            vectorEffect="non-scaling-stroke"
+            initial={{ pathLength: 0, opacity: 0 }}
+            animate={{ pathLength: [0, 1, 1, 1], opacity: [0, 1, 1, 0] }}
+            transition={{
+               duration: CYCLE,
+               repeat: Infinity,
+               times: [0.35, 0.55, 0.85, 1],
+               ease: "easeInOut",
+            }}
+         />
+         {/* the fused identity pulses once the join completes */}
+         <motion.circle
+            cx={(SHARED_FROM.x + SHARED_TO.x) / 2}
+            cy={SHARED_FROM.y}
+            r={2}
+            fill="#22c55e"
+            initial={{ opacity: 0, scale: 0.4 }}
+            animate={{ opacity: [0, 0, 1, 0], scale: [0.4, 0.4, 1.5, 0.4] }}
+            transition={{
+               duration: CYCLE,
+               repeat: Infinity,
+               times: [0, 0.52, 0.62, 0.8],
+               ease: "easeOut",
+            }}
+         />
+      </svg>
+
+      {/* which tree is which */}
+      <div
+         style={{
+            ...label,
+            position: "absolute",
+            left: "7%",
+            bottom: "9%",
+            color: "rgba(255,255,255,0.34)",
+         }}
+      >
+         my tree
+      </div>
+      <div
+         style={{
+            ...label,
+            position: "absolute",
+            right: "7%",
+            bottom: "9%",
+            color: "rgba(255,255,255,0.34)",
+         }}
+      >
+         cousin
+      </div>
+      <motion.div
+         animate={{ opacity: [0.35, 0.35, 0.9, 0.35] }}
+         transition={{
+            duration: CYCLE,
+            repeat: Infinity,
+            times: [0, 0.52, 0.64, 0.85],
+         }}
+         style={{
+            ...label,
+            position: "absolute",
+            left: 0,
+            right: 0,
+            top: "6%",
+            textAlign: "center",
+            fontSize: 6,
+            color: "#22c55ecc",
+         }}
+      >
+         same person
+      </motion.div>
+   </div>
+);
+
+export default GraphScene;

--- a/src/pages/portfolio/covers/MlopsScene.tsx
+++ b/src/pages/portfolio/covers/MlopsScene.tsx
@@ -1,0 +1,382 @@
+import { motion } from "motion/react";
+import { MONO_FONT } from "@/constants/theme";
+
+interface CoverSceneProps {
+   tint: string;
+}
+
+/*
+ * SageMaker MLOps pipeline: S3 event lands -> three architectures train in
+ * parallel -> ensemble -> quality gate -> registered. The gate is the point of
+ * the project, so it gets the beat: it flashes, then the PASS badge resolves.
+ * A drift arc loops back to the trainers to close the retrain circuit.
+ */
+
+const CYCLE = 7;
+
+/* Stage x-positions as percentages of the scene width. */
+const X_INGEST = 12;
+const X_TRAIN = 40;
+const X_GATE = 68;
+const X_REGISTRY = 90;
+
+/* Three architectures, trained in parallel then ensembled. */
+const ARCHES = [
+   { label: "VGG16", top: "26%", delay: 0 },
+   { label: "DENSE", top: "45%", delay: 0.22 },
+   { label: "EFFNET", top: "64%", delay: 0.44 },
+];
+
+const label: React.CSSProperties = {
+   fontFamily: MONO_FONT,
+   fontSize: 7,
+   fontWeight: 700,
+   letterSpacing: "0.12em",
+   textTransform: "uppercase",
+};
+
+/* Hairline rail between two stages. */
+const Rail = ({ from, to, top }: { from: number; to: number; top: string }) => (
+   <div
+      style={{
+         position: "absolute",
+         left: `${from}%`,
+         width: `${to - from}%`,
+         top,
+         height: 1,
+         background: "rgba(255,255,255,0.08)",
+      }}
+   />
+);
+
+/* A packet of training data moving along one rail. */
+const Packet = ({
+   from,
+   to,
+   top,
+   delay,
+   color,
+}: {
+   from: number;
+   to: number;
+   top: string;
+   delay: number;
+   color: string;
+}) => (
+   <motion.div
+      animate={{ left: [`${from}%`, `${to}%`], opacity: [0, 1, 1, 0] }}
+      transition={{
+         duration: CYCLE * 0.3,
+         repeat: Infinity,
+         repeatDelay: CYCLE * 0.7,
+         delay,
+         times: [0, 0.12, 0.85, 1],
+         ease: "easeInOut",
+      }}
+      style={{
+         position: "absolute",
+         top,
+         width: 4,
+         height: 4,
+         marginTop: -2,
+         borderRadius: "50%",
+         background: color,
+      }}
+   />
+);
+
+const MlopsScene = ({ tint }: CoverSceneProps) => (
+   <div
+      aria-hidden="true"
+      style={{
+         position: "absolute",
+         inset: 0,
+         overflow: "hidden",
+         background: `radial-gradient(ellipse at 68% 12%, ${tint}14 0%, transparent 58%), linear-gradient(160deg, #0e1a24 0%, #0b1012 60%)`,
+      }}
+   >
+      {/* dot grid for depth */}
+      <div
+         style={{
+            position: "absolute",
+            inset: 0,
+            opacity: 0.05,
+            backgroundImage:
+               "radial-gradient(rgba(255,255,255,0.6) 1px, transparent 1px)",
+            backgroundSize: "19px 19px",
+         }}
+      />
+
+      {/* terraform hexagon: every resource here is declared, not clicked */}
+      <motion.div
+         animate={{ opacity: [0.45, 0.8, 0.45] }}
+         transition={{ duration: 5, repeat: Infinity, ease: "easeInOut" }}
+         style={{
+            position: "absolute",
+            left: "5%",
+            bottom: "8%",
+            width: 22,
+            height: 25,
+            background: `${tint}14`,
+            clipPath:
+               "polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)",
+         }}
+      />
+      <div
+         style={{
+            ...label,
+            position: "absolute",
+            left: "13%",
+            bottom: "10%",
+            fontSize: 6.5,
+            color: "rgba(255,255,255,0.32)",
+         }}
+      >
+         89 tf / 14 modules
+      </div>
+
+      {/* S3 ingest bucket, pulses when a new object lands */}
+      <motion.div
+         animate={{ borderColor: [`${tint}35`, `${tint}80`, `${tint}35`] }}
+         transition={{
+            duration: CYCLE,
+            repeat: Infinity,
+            times: [0, 0.06, 0.2],
+         }}
+         style={{
+            position: "absolute",
+            left: `${X_INGEST}%`,
+            top: "45%",
+            marginLeft: -17,
+            marginTop: -13,
+            width: 34,
+            height: 26,
+            borderRadius: 5,
+            border: `1px solid ${tint}35`,
+            background: `${tint}08`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+         }}
+      >
+         <span style={{ ...label, fontSize: 7.5, color: `${tint}cc` }}>S3</span>
+      </motion.div>
+
+      {/* fan-out rails: ingest -> each trainer, then trainer -> gate */}
+      {ARCHES.map((a) => (
+         <Rail key={`in-${a.label}`} from={X_INGEST} to={X_TRAIN} top={a.top} />
+      ))}
+      {ARCHES.map((a) => (
+         <Rail key={`out-${a.label}`} from={X_TRAIN} to={X_GATE} top={a.top} />
+      ))}
+      <Rail from={X_GATE} to={X_REGISTRY} top="45%" />
+
+      {/* data flowing in, then predictions flowing out to the gate */}
+      {ARCHES.map((a) => (
+         <Packet
+            key={`p-in-${a.label}`}
+            from={X_INGEST}
+            to={X_TRAIN}
+            top={a.top}
+            delay={a.delay}
+            color="#60a5fa"
+         />
+      ))}
+      {ARCHES.map((a) => (
+         <Packet
+            key={`p-out-${a.label}`}
+            from={X_TRAIN}
+            to={X_GATE}
+            top={a.top}
+            delay={CYCLE * 0.34 + a.delay}
+            color="#38bdf8"
+         />
+      ))}
+
+      {/* the three architectures, each training on its own beat */}
+      {ARCHES.map((a) => (
+         <motion.div
+            key={a.label}
+            animate={{ opacity: [0.5, 1, 0.5] }}
+            transition={{
+               duration: CYCLE,
+               repeat: Infinity,
+               delay: a.delay,
+               times: [0, 0.22, 0.55],
+            }}
+            style={{
+               position: "absolute",
+               left: `${X_TRAIN}%`,
+               top: a.top,
+               marginLeft: -21,
+               marginTop: -8,
+               width: 42,
+               height: 16,
+               borderRadius: 4,
+               border: `1px solid ${tint}30`,
+               background: `${tint}0a`,
+               display: "flex",
+               alignItems: "center",
+               justifyContent: "center",
+            }}
+         >
+            <span
+               style={{
+                  ...label,
+                  fontSize: 6,
+                  color: "rgba(255,255,255,0.52)",
+               }}
+            >
+               {a.label}
+            </span>
+         </motion.div>
+      ))}
+
+      {/* quality gate: the hard condition every model has to clear */}
+      <motion.div
+         animate={{
+            borderColor: [`${tint}30`, "#22c55e70", `${tint}30`],
+         }}
+         transition={{
+            duration: CYCLE,
+            repeat: Infinity,
+            times: [0, 0.62, 0.8],
+         }}
+         style={{
+            position: "absolute",
+            left: `${X_GATE}%`,
+            top: "45%",
+            marginLeft: -18,
+            marginTop: -18,
+            width: 36,
+            height: 36,
+            borderRadius: 6,
+            border: `1px solid ${tint}30`,
+            background: `${tint}08`,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 2,
+         }}
+      >
+         <span style={{ ...label, fontSize: 5.5, color: `${tint}aa` }}>
+            GATE
+         </span>
+         <span
+            style={{
+               fontFamily: MONO_FONT,
+               fontSize: 6,
+               fontWeight: 700,
+               color: "rgba(255,255,255,0.42)",
+            }}
+         >
+            .95
+         </span>
+      </motion.div>
+
+      {/* recall threshold, the strictest of the four gates */}
+      <div
+         style={{
+            ...label,
+            position: "absolute",
+            left: `${X_GATE}%`,
+            top: "72%",
+            marginLeft: -26,
+            width: 52,
+            textAlign: "center",
+            fontSize: 5.5,
+            color: "rgba(255,255,255,0.3)",
+         }}
+      >
+         recall gate
+      </div>
+
+      {/* registry: only reached once the gate passes */}
+      <motion.div
+         animate={{ opacity: [0.3, 0.3, 1, 1, 0.3], scale: [1, 1, 1.1, 1, 1] }}
+         transition={{
+            duration: CYCLE,
+            repeat: Infinity,
+            times: [0, 0.66, 0.74, 0.94, 1],
+         }}
+         style={{
+            position: "absolute",
+            left: `${X_REGISTRY}%`,
+            top: "45%",
+            marginLeft: -9,
+            marginTop: -9,
+            width: 18,
+            height: 18,
+            borderRadius: 4,
+            border: "1px solid #22c55e60",
+            background: "#22c55e12",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+         }}
+      >
+         {/* checkmark */}
+         <div
+            style={{
+               width: 7,
+               height: 4,
+               borderLeft: "1.5px solid #22c55e",
+               borderBottom: "1.5px solid #22c55e",
+               transform: "rotate(-45deg) translateY(-1px)",
+            }}
+         />
+      </motion.div>
+
+      {/* drift arc looping registry -> trainers: Model Monitor restarts training */}
+      <svg
+         viewBox="0 0 100 60"
+         preserveAspectRatio="none"
+         style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+         }}
+      >
+         <path
+            d={`M ${X_REGISTRY} 12 C ${X_REGISTRY} 3, ${X_TRAIN} 3, ${X_TRAIN} 14`}
+            fill="none"
+            stroke={`${tint}28`}
+            strokeWidth={1}
+            strokeDasharray="2 2"
+            vectorEffect="non-scaling-stroke"
+         />
+         <motion.path
+            d={`M ${X_REGISTRY} 12 C ${X_REGISTRY} 3, ${X_TRAIN} 3, ${X_TRAIN} 14`}
+            fill="none"
+            stroke={tint}
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+            initial={{ pathLength: 0, opacity: 0 }}
+            animate={{ pathLength: [0, 0, 1, 1], opacity: [0, 1, 1, 0] }}
+            transition={{
+               duration: CYCLE,
+               repeat: Infinity,
+               times: [0, 0.8, 0.94, 1],
+               ease: "easeInOut",
+            }}
+         />
+      </svg>
+      <div
+         style={{
+            ...label,
+            position: "absolute",
+            right: "8%",
+            top: "6%",
+            fontSize: 5.5,
+            color: "rgba(255,255,255,0.3)",
+         }}
+      >
+         drift retrain
+      </div>
+   </div>
+);
+
+export default MlopsScene;

--- a/src/pages/portfolio/covers/WebAppScene.tsx
+++ b/src/pages/portfolio/covers/WebAppScene.tsx
@@ -22,6 +22,7 @@ const VARIANT_CHIP: Record<string, string> = {
    language: "TUTORS",
    social: "THREADS",
    travel: "JOURNAL",
+   contacts: "CONTACTS",
 };
 
 const PlacementPanel = ({ tint }: { tint: string }) => (
@@ -222,6 +223,48 @@ const TravelPanel = ({ tint }: { tint: string }) => (
    </div>
 );
 
+/* Contact rows with an avatar and a relationship strand to the next person. */
+const ContactsPanel = ({ tint }: { tint: string }) => (
+   <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+      {[0, 1, 2].map((row) => (
+         <motion.div
+            key={row}
+            animate={{ opacity: [0.3, 0.85, 0.3] }}
+            transition={{ duration: 3.2, repeat: Infinity, delay: row * 0.5 }}
+            style={{ display: "flex", alignItems: "center", gap: 6 }}
+         >
+            <span
+               style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  border: `1px solid ${tint}70`,
+                  background: `${tint}20`,
+                  flexShrink: 0,
+               }}
+            />
+            <span
+               style={{
+                  height: 3,
+                  flex: 1,
+                  borderRadius: 2,
+                  background:
+                     row === 0 ? `${tint}55` : "rgba(255,255,255,0.14)",
+               }}
+            />
+            <span
+               style={{
+                  height: 3,
+                  width: 14,
+                  borderRadius: 2,
+                  background: "rgba(255,255,255,0.09)",
+               }}
+            />
+         </motion.div>
+      ))}
+   </div>
+);
+
 const DefaultPanel = ({ tint }: { tint: string }) => (
    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
       {[0, 1, 2].map((row) => (
@@ -246,6 +289,7 @@ const WebAppScene = ({ tint, variant }: CoverSceneProps) => {
    else if (variant === "language") panel = <LanguagePanel tint={tint} />;
    else if (variant === "social") panel = <SocialPanel tint={tint} />;
    else if (variant === "travel") panel = <TravelPanel tint={tint} />;
+   else if (variant === "contacts") panel = <ContactsPanel tint={tint} />;
    else panel = <DefaultPanel tint={tint} />;
 
    const chip = VARIANT_CHIP[variant ?? ""];

--- a/src/pages/portfolio/covers/coverRegistry.ts
+++ b/src/pages/portfolio/covers/coverRegistry.ts
@@ -30,6 +30,8 @@ type SceneComponent = ComponentType<SceneCoverProps>;
 const InfraScene = lazy(() => import("./InfraScene"));
 const McpScene = lazy(() => import("./McpScene"));
 const MlScene = lazy(() => import("./MlScene"));
+const MlopsScene = lazy(() => import("./MlopsScene"));
+const GraphScene = lazy(() => import("./GraphScene"));
 const GameScene = lazy(() => import("./GameScene"));
 const DocsScene = lazy(() => import("./DocsScene"));
 const AutomationScene = lazy(() => import("./AutomationScene"));
@@ -46,6 +48,8 @@ export type ProjectCover =
  */
 const COVER_BY_ID: Record<number, ProjectCover> = {
    // Featured
+   49: { kind: "scene", Scene: MlopsScene }, // SageMaker Image Classification MLOps
+   50: { kind: "scene", Scene: GraphScene }, // Kinfolk (family DAG)
    44: { kind: "image", src: kalchar }, // Kalchar (kalchar.co.in)
    37: { kind: "image", src: gitscope }, // GitScope (Chrome Web Store shot)
    15: { kind: "image", src: ledgerSync },
@@ -64,6 +68,7 @@ const COVER_BY_ID: Record<number, ProjectCover> = {
    27: { kind: "image", src: noobathon },
 
    // Others
+   51: { kind: "scene", Scene: WebAppScene, variant: "contacts" }, // Orbit (personal CRM)
    46: { kind: "image", src: sagas }, // Sagas (sagargupta.online/sagas)
    48: { kind: "image", src: contactManager }, // Contact Manager
    40: { kind: "scene", Scene: AutomationScene, variant: "instagram" }, // Instagram Autopilot


### PR DESCRIPTION
## Why

A fleet sweep turned up three factual errors on the live site, two shipped projects that were missing, and three cards rendering with an empty media slot.

## Content corrections

All three verified against live sources, not assumed:

| Issue | Evidence |
| --- | --- |
| `ITR MCP` pointed at `itr-mcp` on GitHub and npm | Repo and package were renamed 2026-07-21; the npm registry reports `itr-mcp` deprecated and frozen at 0.2.0, `itr-agent` live at 0.3.0. Visitors were landing on a deprecation banner. |
| `Lingua Connect` pointed at `TRINIT_BugBiters_Dev` | Only resolved through a GitHub rename redirect. |
| `awslabs/mcp#4076` listed as open | Closed 2026-08-05 by a stale bot. All 17 OSS entries were checked against the API; this was the only drift. `open_source_prs` moves from `9 merged + 7 open` to `9 merged + 6 open`. |

The ITR description is also reframed from calculator to filing agent, matching the 12-tool v0.3.0 release.

## New projects

- **Kinfolk** (featured) - public, MIT, v0.3.2, live at both `sagargupta.online/kinfolk/` and the Vercel demo host (both confirmed 200). Family modelled as a DAG rather than a tree, with consent-gated cross-tree merging.
- **Orbit** (others) - personal CRM, OAuth plus a Neon-backed contacts dashboard, live at `sagargupta.online/orbit/` (confirmed 200). Deliberately described as contacts-only: interactions, circles, and reminders are in the schema but have no UI yet.

`projects` stat moves from `40+` to `44+`.

## Animated covers

Ids 49, 50, and 51 had no entry in `COVER_BY_ID`, so `getProjectCover` returned undefined and `ProjectCover` returned null, leaving those cards with no media while every sibling had one.

- **`MlopsScene`** (new) - S3 event to three architectures training in parallel (VGG16 / DenseNet / EfficientNet) to the quality gate to the registry, with a drift-retrain arc closing the loop. Grounded in the actual README: 89 Terraform files, 14 modules, the recall gate.
- **`GraphScene`** (new) - two family trees that share a person; the dashed candidate match resolves into a solid consent-gated join.
- **`contacts` variant** on the existing `WebAppScene` for Orbit, rather than a third new file.

Both new scenes are lazy, so they ship as their own chunks. Aesthetic constraints respected: blue accent family only, green reserved for success states, transform and opacity only, no reduced-motion gating.

## Verification

- Clean `pnpm type-check` and `pnpm lint` (zero-warnings).
- `prettier --check` clean on every touched file. Note `data/projects.json` carries pre-existing formatter drift on `main`, confirmed present at HEAD before these edits; deliberately not reformatted to keep this diff reviewable.
- `pnpm test` 4/4 across three consecutive runs.
- `pnpm build` green, with `GraphScene` and `MlopsScene` emitted as separate chunks.
- Both new scenes confirmed mounted in the DOM with their full element set (MLOps: S3, VGG16, DENSE, EFFNET, GATE, recall gate, drift retrain; Kinfolk: 9 person nodes, 8 edges, the "same person" join) and the tint resolving to the correct `#60a5fa`.

Live pixel verification was not possible: the Browser pane reports `document.hidden` with a 0x0 viewport, which pauses rAF and makes every rect report zero. The CSS contract was verified instead (`aspect-ratio: 16 / 10`, `inset: 0`, correct `viewBox`, no stuck skeleton).