### PR TITLE
chore: bring the repo to a clean prettier baseline

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,12 @@
+# Build output
+build/
+
+# Generated, not hand-maintained. Formatting these only creates churn:
+# a tool rewrites them on its own schedule and undoes whatever we do here.
+pnpm-lock.yaml
+# scripts/sync-credly.js writes this with JSON.stringify(_, null, 2) every week,
+# which is 2-space where our config is 3-space. See the Credly note in CLAUDE.md.
+data/achievements.json
+
+# Knowledge graph output (gitignored, but keep prettier off it locally too)
+graphify-out/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,10 @@
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| Latest (main branch) | Yes |
-| Older releases | No |
+| Version              | Supported |
+| -------------------- | --------- |
+| Latest (main branch) | Yes       |
+| Older releases       | No        |
 
 ## Reporting a Vulnerability
 
@@ -14,12 +14,14 @@ If you discover a security vulnerability in this project, please report it respo
 **Email:** sg85207@gmail.com
 
 **What to include:**
+
 - Description of the vulnerability
 - Steps to reproduce
 - Potential impact
 - Suggested fix (if any)
 
 **Response timeline:**
+
 - Acknowledgment within 48 hours
 - Status update within 7 days
 - Fix or mitigation within 30 days for confirmed vulnerabilities

--- a/data/projects.json
+++ b/data/projects.json
@@ -217,12 +217,7 @@
          "title": "SelfHub",
          "description": "A Model Context Protocol (MCP) server that acts as your personal digital memory hub - store notes, preferences, code snippets, tasks, and any info from any MCP-enabled AI assistant (Claude Desktop, VS Code Copilot). Your personal knowledge base travels with you across AI conversations.",
          "date": "March 2025",
-         "tools_tech": [
-            "TypeScript",
-            "MCP",
-            "Node.js",
-            "pnpm"
-         ],
+         "tools_tech": ["TypeScript", "MCP", "Node.js", "pnpm"],
          "features": [
             "MCP-compliant server with stdio transport for Claude Desktop + VS Code",
             "store_memory, list_memories, search_memories, and more tools",
@@ -258,10 +253,7 @@
          "github": "https://github.com/Sagargupta16/code-arena",
          "live": "https://sagargupta.online/code-arena/",
          "team": "Sagar & Pranshu",
-         "contributors": [
-            "Sagargupta16",
-            "Pranshu"
-         ]
+         "contributors": ["Sagargupta16", "Pranshu"]
       },
       {
          "id": 21,
@@ -287,10 +279,7 @@
          "live": "",
          "team": "MCA NITW Placement Team",
          "organization": "MCA-NITW",
-         "contributors": [
-            "Sagargupta16",
-            "MCA NITW Team"
-         ]
+         "contributors": ["Sagargupta16", "MCA NITW Team"]
       },
       {
          "id": 1,
@@ -316,10 +305,7 @@
          "live": "",
          "team": "BugBiters",
          "organization": "TriNIT",
-         "contributors": [
-            "Sagargupta16",
-            "Team Members"
-         ]
+         "contributors": ["Sagargupta16", "Team Members"]
       },
       {
          "id": 4,
@@ -343,10 +329,7 @@
          "live": "https://leetcode-among-us.onrender.com/",
          "team": "MCA NITW Dev Team",
          "organization": "MCA-NITW",
-         "contributors": [
-            "Sagargupta16",
-            "MCA NITW Team"
-         ]
+         "contributors": ["Sagargupta16", "MCA NITW Team"]
       },
       {
          "id": 23,
@@ -371,21 +354,14 @@
          "live": "",
          "team": "MCA NITW Dev Team",
          "organization": "MCA-NITW",
-         "contributors": [
-            "Sagargupta16",
-            "MCA NITW Team"
-         ]
+         "contributors": ["Sagargupta16", "MCA NITW Team"]
       },
       {
          "id": 27,
          "title": "Noobathon",
          "description": "A team hackathon project built during MCA 1st year at the CSEA Noobathon event, featuring a responsive web page created collaboratively in a team of 3.",
          "date": "April 2022",
-         "tools_tech": [
-            "HTML5",
-            "CSS3",
-            "Hackathon"
-         ],
+         "tools_tech": ["HTML5", "CSS3", "Hackathon"],
          "features": [
             "Built in a team of 3",
             "CSEA Noobathon hackathon entry",
@@ -396,10 +372,7 @@
          "live": "https://sayani13-glitch.github.io/noobathon_ON-11_1/",
          "team": "Team SKS",
          "organization": "CSEA NIT Warangal",
-         "contributors": [
-            "Sagargupta16",
-            "Team SKS"
-         ]
+         "contributors": ["Sagargupta16", "Team SKS"]
       }
    ],
    "other_projects": [
@@ -655,12 +628,7 @@
          "title": "PacMan Game Unity",
          "description": "A classic Pac-Man game recreated using Unity Engine with C# scripting for an authentic gaming experience.",
          "date": "June 2022",
-         "tools_tech": [
-            "Unity",
-            "C#",
-            "Game Development",
-            "Unity2D"
-         ],
+         "tools_tech": ["Unity", "C#", "Game Development", "Unity2D"],
          "features": [
             "Classic Pac-Man gameplay",
             "Unity2D graphics",
@@ -675,12 +643,7 @@
          "title": "Minesweeper Game Unity",
          "description": "A classic Minesweeper game recreated using Unity Engine with C# scripting, featuring grid-based gameplay and mine detection mechanics.",
          "date": "June 2022",
-         "tools_tech": [
-            "Unity",
-            "C#",
-            "Game Development",
-            "Unity2D"
-         ],
+         "tools_tech": ["Unity", "C#", "Game Development", "Unity2D"],
          "features": [
             "Classic Minesweeper gameplay",
             "Grid-based mine detection",
@@ -695,12 +658,7 @@
          "title": "Snake Game Unity",
          "description": "A classic Snake game built using Unity Engine with C# scripting, featuring smooth movement mechanics and score tracking.",
          "date": "June 2022",
-         "tools_tech": [
-            "Unity",
-            "C#",
-            "Game Development",
-            "Unity2D"
-         ],
+         "tools_tech": ["Unity", "C#", "Game Development", "Unity2D"],
          "features": [
             "Classic Snake gameplay",
             "Smooth movement mechanics",
@@ -715,12 +673,7 @@
          "title": "Flappy Bird Game Unity",
          "description": "A Flappy Bird clone built using Unity Engine with C# scripting, featuring physics-based gameplay and obstacle generation.",
          "date": "June 2022",
-         "tools_tech": [
-            "Unity",
-            "C#",
-            "Game Development",
-            "Unity2D"
-         ],
+         "tools_tech": ["Unity", "C#", "Game Development", "Unity2D"],
          "features": [
             "Flappy Bird gameplay",
             "Physics-based mechanics",
@@ -735,11 +688,7 @@
          "title": "Music Web Player",
          "description": "A modern music player with glassmorphism UI, built with vanilla HTML, CSS, and JavaScript. Features shuffle/repeat modes, rotating album art, and a seekable progress bar.",
          "date": "May 2022",
-         "tools_tech": [
-            "HTML5",
-            "CSS3",
-            "JavaScript"
-         ],
+         "tools_tech": ["HTML5", "CSS3", "JavaScript"],
          "features": [
             "Glassmorphism UI design",
             "Shuffle and repeat playback modes",
@@ -777,12 +726,7 @@
          "title": "ITR Agent",
          "description": "Local-first MCP server that walks you through filing an Indian income tax return, published on npm. 12 tools spanning form selection, deterministic computation, old-vs-new regime comparison, advance tax planning, and document parsing - all on your machine. The LLM never does arithmetic; every number comes from a versioned, auditable rule pack. Works with Claude Desktop, Claude Code, and any MCP client.",
          "date": "July 2026",
-         "tools_tech": [
-            "TypeScript",
-            "MCP Protocol",
-            "Node.js",
-            "npm"
-         ],
+         "tools_tech": ["TypeScript", "MCP Protocol", "Node.js", "npm"],
          "features": [
             "recommend_itr_form picks ITR-1/2/3/4 with rule-by-rule reasoning, including brought-forward losses that force ITR-3",
             "file_my_itr guided interview plus a schedule-by-schedule filing checklist ending at e-verification",
@@ -863,12 +807,7 @@
          "title": "MCP Toolkit",
          "description": "Reusable utilities and middleware for building production-ready MCP servers. Drop-in packages for the TypeScript SDK covering auth, caching, rate limiting, logging, and CORS - so you stop reimplementing the same plumbing for every MCP server.",
          "date": "March 2025",
-         "tools_tech": [
-            "TypeScript",
-            "MCP Protocol",
-            "Node.js",
-            "npm"
-         ],
+         "tools_tech": ["TypeScript", "MCP Protocol", "Node.js", "npm"],
          "features": [
             "@mcp-toolkit/auth - API key and JWT authentication",
             "@mcp-toolkit/cache - response caching with TTL and LRU",
@@ -903,11 +842,7 @@
          "title": "Awesome MCP Servers",
          "description": "A curated [awesome] list of Model Context Protocol servers, frameworks, clients, tutorials, and community resources - covering data, developer tools, cloud, productivity, search, AI/ML, finance, and observability.",
          "date": "March 2025",
-         "tools_tech": [
-            "MCP Protocol",
-            "AI Agents",
-            "Curated List"
-         ],
+         "tools_tech": ["MCP Protocol", "AI Agents", "Curated List"],
          "features": [
             "Categorized MCP server directory (Data, Dev Tools, Cloud, AI/ML, Finance)",
             "Frameworks and clients listings with official SDKs and Inspector",
@@ -944,12 +879,7 @@
          "title": "Agent Recipes",
          "description": "Copy-paste AI agent workflows for real-world developer tasks - code review, testing, migrations, documentation, security scanning, and deployment automation. Works with Claude Code, Cursor, Aider, or any AI coding assistant.",
          "date": "March 2025",
-         "tools_tech": [
-            "AI Agents",
-            "Claude Code",
-            "Cursor",
-            "Aider"
-         ],
+         "tools_tech": ["AI Agents", "Claude Code", "Cursor", "Aider"],
          "features": [
             "Code review: PR review, architecture review, dependency audit, performance review",
             "Testing: unit test generation, E2E writer, coverage gap finder",
@@ -964,13 +894,7 @@
          "title": "AI Git Hooks",
          "description": "AI-powered git hooks that review code, generate commit messages, catch bugs, and scan for security issues before you push. Drop-in hooks using Claude, OpenAI, or local Ollama for every stage of your git workflow.",
          "date": "March 2025",
-         "tools_tech": [
-            "Git Hooks",
-            "Claude",
-            "OpenAI",
-            "Ollama",
-            "Bash"
-         ],
+         "tools_tech": ["Git Hooks", "Claude", "OpenAI", "Ollama", "Bash"],
          "features": [
             "pre-commit: AI code review for bugs, style, anti-patterns",
             "prepare-commit-msg: auto-generated conventional commit messages from diff",

--- a/index.html
+++ b/index.html
@@ -60,51 +60,64 @@
 
       <!-- JSON-LD Structured Data -->
       <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@graph": [
-          {
-            "@type": "Person",
-            "@id": "https://sagargupta.online/#person",
-            "name": "Sagar Gupta",
-            "url": "https://sagargupta.online",
-            "image": "https://avatars.githubusercontent.com/u/92421383",
-            "jobTitle": "Cloud Consultant - DevOps/MLOps",
-            "description": "DevOps/MLOps Consultant at AWS Professional Services. 6x AWS Certified. Building cloud infrastructure, CI/CD pipelines, and ML engineering solutions for enterprise clients.",
-            "worksFor": {
-              "@type": "Organization",
-              "name": "Amazon Web Services",
-              "url": "https://aws.amazon.com"
-            },
-            "alumniOf": {
-              "@type": "CollegeOrUniversity",
-              "name": "National Institute of Technology, Warangal",
-              "url": "https://www.nitw.ac.in"
-            },
-            "address": {
-              "@type": "PostalAddress",
-              "addressLocality": "Hyderabad",
-              "addressCountry": "IN"
-            },
-            "sameAs": [
-              "https://github.com/Sagargupta16",
-              "https://www.linkedin.com/in/sagar-gupta-16-10/",
-              "https://www.instagram.com/sagar_sethh/",
-              "https://x.com/Sagargupta1610",
-              "https://leetcode.com/u/Sagargupta16"
-            ],
-            "knowsAbout": ["AWS", "DevOps", "MLOps", "Terraform", "Python", "React", "CI/CD", "Cloud Infrastructure", "Docker", "Kubernetes", "SageMaker", "FastAPI"]
-          },
-          {
-            "@type": "WebSite",
-            "@id": "https://sagargupta.online/portfolio-react/#website",
-            "url": "https://sagargupta.online/portfolio-react/",
-            "name": "Sagar Gupta Portfolio",
-            "description": "Portfolio of Sagar Gupta - DevOps & Cloud Consultant at AWS. Cloud infrastructure, CI/CD automation, ML engineering, and 25+ projects.",
-            "author": { "@id": "https://sagargupta.online/#person" }
-          }
-        ]
-      }
+         {
+            "@context": "https://schema.org",
+            "@graph": [
+               {
+                  "@type": "Person",
+                  "@id": "https://sagargupta.online/#person",
+                  "name": "Sagar Gupta",
+                  "url": "https://sagargupta.online",
+                  "image": "https://avatars.githubusercontent.com/u/92421383",
+                  "jobTitle": "Cloud Consultant - DevOps/MLOps",
+                  "description": "DevOps/MLOps Consultant at AWS Professional Services. 6x AWS Certified. Building cloud infrastructure, CI/CD pipelines, and ML engineering solutions for enterprise clients.",
+                  "worksFor": {
+                     "@type": "Organization",
+                     "name": "Amazon Web Services",
+                     "url": "https://aws.amazon.com"
+                  },
+                  "alumniOf": {
+                     "@type": "CollegeOrUniversity",
+                     "name": "National Institute of Technology, Warangal",
+                     "url": "https://www.nitw.ac.in"
+                  },
+                  "address": {
+                     "@type": "PostalAddress",
+                     "addressLocality": "Hyderabad",
+                     "addressCountry": "IN"
+                  },
+                  "sameAs": [
+                     "https://github.com/Sagargupta16",
+                     "https://www.linkedin.com/in/sagar-gupta-16-10/",
+                     "https://www.instagram.com/sagar_sethh/",
+                     "https://x.com/Sagargupta1610",
+                     "https://leetcode.com/u/Sagargupta16"
+                  ],
+                  "knowsAbout": [
+                     "AWS",
+                     "DevOps",
+                     "MLOps",
+                     "Terraform",
+                     "Python",
+                     "React",
+                     "CI/CD",
+                     "Cloud Infrastructure",
+                     "Docker",
+                     "Kubernetes",
+                     "SageMaker",
+                     "FastAPI"
+                  ]
+               },
+               {
+                  "@type": "WebSite",
+                  "@id": "https://sagargupta.online/portfolio-react/#website",
+                  "url": "https://sagargupta.online/portfolio-react/",
+                  "name": "Sagar Gupta Portfolio",
+                  "description": "Portfolio of Sagar Gupta - DevOps & Cloud Consultant at AWS. Cloud infrastructure, CI/CD automation, ML engineering, and 25+ projects.",
+                  "author": { "@id": "https://sagargupta.online/#person" }
+               }
+            ]
+         }
       </script>
 
       <!-- Favicons -->
@@ -167,8 +180,7 @@
             // Google Analytics (gtag)
             var ga = d.createElement("script");
             ga.async = true;
-            ga.src =
-               "https://www.googletagmanager.com/gtag/js?id=G-PFFMG7D8DP";
+            ga.src = "https://www.googletagmanager.com/gtag/js?id=G-PFFMG7D8DP";
             d.body.appendChild(ga);
 
             globalThis.dataLayer = globalThis.dataLayer || [];

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,13 +1,13 @@
 allowBuilds:
-  esbuild: true
+   esbuild: true
 
 overrides:
-  "@isaacs/brace-expansion": ">=5.0.1"
-  minimatch: ">=10.2.3"
-  js-yaml: ">=4.1.1"
-  "ajv@<7": "~6.15.0"
-  "rollup@>=4.0.0 <4.59.0": ">=4.59.0"
-  undici: "<9"
-  flatted: ">=3.4.0"
-  yaml: ">=2.8.3"
-  esbuild: ">=0.28.1"
+   "@isaacs/brace-expansion": ">=5.0.1"
+   minimatch: ">=10.2.3"
+   js-yaml: ">=4.1.1"
+   "ajv@<7": "~6.15.0"
+   "rollup@>=4.0.0 <4.59.0": ">=4.59.0"
+   undici: "<9"
+   flatted: ">=3.4.0"
+   yaml: ">=2.8.3"
+   esbuild: ">=0.28.1"

--- a/renovate.json
+++ b/renovate.json
@@ -1,1 +1,4 @@
-{"$schema":"https://docs.renovatebot.com/renovate-schema.json","extends":["github>Sagargupta16/shared-workflows"]}
+{
+   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+   "extends": ["github>Sagargupta16/shared-workflows"]
+}

--- a/src/components/ui/CvViewerModal/CvDocument.tsx
+++ b/src/components/ui/CvViewerModal/CvDocument.tsx
@@ -30,7 +30,9 @@ const CvDocument = ({ isMobile }: CvDocumentProps) => {
    useEffect(() => {
       let cancelled = false;
       fetch(MANIFEST_URL)
-         .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`${r.status}`))))
+         .then((r) =>
+            r.ok ? r.json() : Promise.reject(new Error(`${r.status}`)),
+         )
          .then((m: Manifest) => {
             if (!cancelled) setManifest(m);
          })

--- a/src/pages/services/animations/AiDlcAnim.tsx
+++ b/src/pages/services/animations/AiDlcAnim.tsx
@@ -144,7 +144,10 @@ const AiDlcAnim = ({ color }: AiDlcAnimProps) => (
 
       {/* Shipped check */}
       <motion.div
-         animate={{ opacity: [0.35, 0.35, 1, 1, 0.35], scale: [1, 1, 1.15, 1, 1] }}
+         animate={{
+            opacity: [0.35, 0.35, 1, 1, 0.35],
+            scale: [1, 1, 1.15, 1, 1],
+         }}
          transition={{
             duration: CYCLE,
             repeat: Infinity,


### PR DESCRIPTION
## Why

`prettier . --check` failed on **9 files** on `main`. That meant any content edit which tripped the format-on-write hook came back with a diff full of unrelated churn - during the last change a ~20 line edit to `data/projects.json` turned into 129 changed lines of array collapsing, and had to be reverted and redone another way.

This is that reformatting on its own, with zero content change, so future content diffs stay readable.

## Two files are generated, so they are ignored rather than formatted

Adds a `.prettierignore` (the repo had none, so `prettier .` was sweeping generated files):

| File | Why ignored |
| --- | --- |
| `pnpm-lock.yaml` | written by pnpm |
| `data/achievements.json` | `scripts/sync-credly.js` rewrites it weekly with `JSON.stringify(_, null, 2)`, which is 2-space where our config is 3-space. Formatting it would be undone by the next sync. |

`build/` and `graphify-out/` are listed too.

## The other 7 are pure reformatting

Line wrapping to the 80 column `printWidth` and indentation. No logic, no content, no copy.

`SECURITY.md`, `data/projects.json`, `index.html`, `pnpm-workspace.yaml`, `renovate.json`, `src/components/ui/CvViewerModal/CvDocument.tsx`, `src/pages/services/animations/AiDlcAnim.tsx`.

## Verification

Semantic equivalence checked per file type rather than assumed:

- `data/projects.json` is **byte-identical** after a `json.dumps(sort_keys=True)` round trip before and after.
- `renovate.json` still parses; all **9** `pnpm-workspace.yaml` overrides survive (indent-only change).
- `index.html` keeps its JSON-LD block (structured data identical after parsing) and all **22** meta tags (identical whitespace-normalized). This matters because that file carries the SEO payload.
- Clean `pnpm type-check`, clean `pnpm lint` (zero-warnings), 4/4 vitest.
- `prettier . --check` now passes across the whole repo.

**Strongest evidence runtime output is untouched:** `pnpm build` emits `index-7jFGgqt5.js` and `Portfolio-BmwexORD.js` - the exact same content hashes currently serving in production. Identical hashes mean identical bytes.